### PR TITLE
Add Waitlist Endpoints

### DIFF
--- a/models/Waitlist.ts
+++ b/models/Waitlist.ts
@@ -1,5 +1,5 @@
 /**
- * Request Body Input for waitlist APIs
+ * Request Body Input for waitlist endpoint
  */
 export type WaitlistInput = {
     classId?: number;

--- a/models/Waitlist.ts
+++ b/models/Waitlist.ts
@@ -1,0 +1,7 @@
+/**
+ * Request Body Input for waitlist APIs
+ */
+export type WaitlistInput = {
+    classId?: number;
+    parentId?: number;
+};

--- a/pages/api/class/[id].ts
+++ b/pages/api/class/[id].ts
@@ -15,7 +15,7 @@ export default async function handle(
     // Obtain class id
     const { id } = req.query;
     if (req.method == "GET") {
-        // obtain program with provided programId
+        // obtain class with provided classId
         const classSection = await getClass(id as string);
 
         if (!classSection) {
@@ -34,7 +34,7 @@ export default async function handle(
         ResponseUtil.returnOK(res, deletedClass);
         return;
     } else {
-        const allowedHeaders: string[] = ["GET"];
+        const allowedHeaders: string[] = ["GET", "DELETE"];
         ResponseUtil.returnMethodNotAllowed(
             res,
             allowedHeaders,

--- a/pages/api/waitlist/index.ts
+++ b/pages/api/waitlist/index.ts
@@ -60,7 +60,7 @@ export default async function handle(
                     res,
                     `Waitlist record could not be created`,
                 );
-                break;
+                return;
             }
             ResponseUtil.returnOK(res, newWaitlistRecord);
             break;
@@ -78,7 +78,7 @@ export default async function handle(
                     res,
                     `Waitlist record with parentId:${input.parentId}, classId:${input.classId} not found.`,
                 );
-                break;
+                return;
             }
             ResponseUtil.returnOK(res, deleteWaitlistRecord);
             break;

--- a/pages/api/waitlist/index.ts
+++ b/pages/api/waitlist/index.ts
@@ -1,0 +1,96 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { ResponseUtil } from "@utils/responseUtil";
+import {
+    getWaitlistRecord,
+    getWaitlistRecordsByClassId,
+    getWaitlistRecordsByParentId,
+    createWaitlistRecord,
+    deleteWaitlistRecord,
+} from "@database/waitlist";
+import { WaitlistInput } from "models/Waitlist";
+import { validateWaitlistRecord } from "@utils/validation/waitlist";
+
+/**
+ * handle controls the request made to the waitlist resource
+ * @param req API request object
+ * @param res API response object
+ */
+export default async function handle(
+    req: NextApiRequest,
+    res: NextApiResponse,
+): Promise<void> {
+    switch (req.method) {
+        // Retrieving a waitlist by passing in the classId and parentId.
+        case "GET": {
+            const input = req.body as WaitlistInput;
+
+            if (input.classId && input.parentId) {
+                // If both classId and parentId are passed in, retrieve the specific waitlist record
+                const waitlistRecord = await getWaitlistRecord(input);
+                ResponseUtil.returnOK(res, waitlistRecord);
+            } else if (input.classId) {
+                // If only classId was passed in, retrieve all waitlist records for the class
+                const waitlistRecordsForClass =
+                    await getWaitlistRecordsByClassId(input.classId);
+                ResponseUtil.returnOK(res, waitlistRecordsForClass);
+            } else if (input.parentId) {
+                // If only the parentId was passed in, retrieve all waitlist records for the parent
+                const waitlistRecordsForParent =
+                    await getWaitlistRecordsByParentId(input.parentId);
+                ResponseUtil.returnOK(res, waitlistRecordsForParent);
+            } else {
+                // If neither the classId or the parentId are passed in
+                ResponseUtil.returnBadRequest(
+                    res,
+                    `Required input for retrieving a waitlist record was not provided`,
+                );
+            }
+            break;
+        }
+        case "POST": {
+            const input = req.body as WaitlistInput;
+            const validationErrors = validateWaitlistRecord(input);
+            if (validationErrors.length !== 0) {
+                ResponseUtil.returnBadRequest(res, validationErrors.join(", "));
+                return;
+            }
+            const newWaitlistRecord = await createWaitlistRecord(input);
+            if (!newWaitlistRecord) {
+                ResponseUtil.returnBadRequest(
+                    res,
+                    `Waitlist record could not be created`,
+                );
+                break;
+            }
+            ResponseUtil.returnOK(res, newWaitlistRecord);
+            break;
+        }
+        case "DELETE": {
+            const input = req.body as WaitlistInput;
+            const validationErrors = validateWaitlistRecord(input);
+            if (validationErrors.length !== 0) {
+                ResponseUtil.returnBadRequest(res, validationErrors.join(", "));
+                return;
+            }
+            const deletedWaitlistRecord = await deleteWaitlistRecord(input);
+            if (!deletedWaitlistRecord) {
+                ResponseUtil.returnNotFound(
+                    res,
+                    `Waitlist record with parentId:${input.parentId}, classId:${input.classId} not found.`,
+                );
+                break;
+            }
+            ResponseUtil.returnOK(res, deleteWaitlistRecord);
+            break;
+        }
+        default: {
+            const allowedHeaders: string[] = ["GET", "POST", "DELETE"];
+            ResponseUtil.returnMethodNotAllowed(
+                res,
+                allowedHeaders,
+                `Method ${req.method} Not Allowed`,
+            );
+        }
+    }
+    return;
+}

--- a/services/database/class.ts
+++ b/services/database/class.ts
@@ -29,7 +29,6 @@ async function getClasses(): Promise<Class[]> {
  * @returns Promise<Class> - Promise with the newly created class
  */
 async function createClass(input: CreateClassInput): Promise<Class> {
-    console.log(input);
     const newClass = await prisma.class.create({
         data: {
             name: input.name,

--- a/services/database/waitlist.ts
+++ b/services/database/waitlist.ts
@@ -1,0 +1,97 @@
+import prisma from "@database";
+import { Waitlist } from "@prisma/client";
+import { WaitlistInput } from "models/Waitlist";
+/**
+ * getWaitlistRecord takes the classId and parentId and returns the associated waitlist
+ * @param classId
+ * @param parentId
+ */
+async function getWaitlistRecord(input: WaitlistInput): Promise<Waitlist> {
+    const waitlistRecord = await prisma.waitlist.findUnique({
+        where: {
+            parentId_classId: {
+                classId: input.classId,
+                parentId: input.parentId,
+            },
+        },
+    });
+    return waitlistRecord;
+}
+
+/**
+ * getWaitlistRecordsByClassId returns a list of waitlists associated with the classId
+ * @param classId
+ * @returns Promise<Waitlist[]> - Promise with list of waitlist records associated with the class
+ */
+async function getWaitlistRecordsByClassId(
+    classId: number,
+): Promise<Waitlist[]> {
+    const waitlistRecords = await prisma.waitlist.findMany({
+        where: {
+            classId: classId,
+        },
+        orderBy: {
+            createdAt: "asc",
+        },
+    });
+    return waitlistRecords;
+}
+
+/**
+ * getWaitlistRecordsByParentId returns a list of waitlist records associated with the parentId
+ * @param parentId
+ * @returns Promise<Waitlist[]> - Promise with list of waitlist records associated with the parent
+ */
+async function getWaitlistRecordsByParentId(
+    parentId: number,
+): Promise<Waitlist[]> {
+    const waitlistRecords = await prisma.waitlist.findMany({
+        where: {
+            parentId: parentId,
+        },
+        orderBy: {
+            createdAt: "asc",
+        },
+    });
+    return waitlistRecords;
+}
+
+/**
+ * createWaitlistRecord creates a new waitlist record
+ * @param input - data of type WaitlistInput
+ * @returns Promise<Waitlist> - Promise with the newly created waitlist record
+ */
+async function createWaitlistRecord(input: WaitlistInput): Promise<Waitlist> {
+    const waitlistRecord = await prisma.waitlist.create({
+        data: {
+            classId: input.classId,
+            parentId: input.parentId,
+        },
+    });
+    return waitlistRecord;
+}
+
+/**
+ * deleteWaitlistRecord deletes a waitlist record
+ * @param input - data of type WaitlistInput
+ * @returns Promise<Class> - Promise with the deleted class
+ */
+async function deleteWaitlistRecord(input: WaitlistInput): Promise<Waitlist> {
+    const deletedWaitlistRecord = await prisma.waitlist.delete({
+        where: {
+            parentId_classId: {
+                classId: input.classId,
+                parentId: input.parentId,
+            },
+        },
+    });
+    return deletedWaitlistRecord;
+}
+
+export {
+    getWaitlistRecord,
+    getWaitlistRecordsByClassId,
+    getWaitlistRecordsByParentId,
+    createWaitlistRecord,
+    deleteWaitlistRecord,
+};

--- a/services/database/waitlist.ts
+++ b/services/database/waitlist.ts
@@ -31,7 +31,7 @@ async function getWaitlistRecordsByClassId(
             classId: classId,
         },
         orderBy: {
-            createdAt: "asc",
+            createdAt: "asc", // ascending order as the oldest createdAt date is the highest priority.
         },
     });
     return waitlistRecords;

--- a/utils/validation/waitlist.ts
+++ b/utils/validation/waitlist.ts
@@ -1,0 +1,20 @@
+import { WaitlistInput } from "models/Waitlist";
+
+/**
+ * validateWaitlistRecord takes input of type WaitlistInput and validates the input
+ * @param input - data corresponding to a waitlist
+ * @returns string[] - array of errors of type string
+ */
+export function validateWaitlistRecord(input: WaitlistInput): string[] {
+    const validationErrors = [];
+
+    if (!input.classId) {
+        validationErrors.push("classId is not provided");
+    }
+
+    if (!input.parentId) {
+        validationErrors.push("parentId is not provided");
+    }
+
+    return validationErrors;
+}

--- a/utils/validation/waitlist.ts
+++ b/utils/validation/waitlist.ts
@@ -6,7 +6,7 @@ import { WaitlistInput } from "models/Waitlist";
  * @returns string[] - array of errors of type string
  */
 export function validateWaitlistRecord(input: WaitlistInput): string[] {
-    const validationErrors = [];
+    const validationErrors: string[] = [];
 
     if (!input.classId) {
         validationErrors.push("classId is not provided");


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Waitlist Endpoints](https://www.notion.so/uwblueprintexecs/086c1b564dbf478faa649a8880e34b81?v=9d3f8002a0d1477ba395616dfc082af7&p=9da31aea03274a1b9fbab45ee9575544)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- GET endpoint for waitlists. If both parentId and classId are passed in, we find the specific waitlist record. If only the parentId is passed in, we get all waitlist records associated with the parent. If only the classId is passed in, we get all waitlist records associated with the class
- POST endpoint: Validate the input to ensure both parentId and classId are passed in and then create the waitlist record
- DELETE endpoint: Validate the input to ensure both parentId and classId are passed in and then delete the waitlist record 

### Steps to test

1. Try the endpoints on postman. In order to create a waitlist record, it has to be associated with a parent and class. Thus, those need to be created prior to creating a waitlist.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-  I haven't manually tested the code since it's blocked on parent and class stuff being complete so it would be best if you guys could look through it closely to minimize bugs.

### Checklist

-   [ ] My PR name is descriptive and in imperative tense
-   [ ] I have run the linter
-   [ ] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
