### PR TITLE
Add single page for initial signup form

### DIFF
--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,75 @@
+import {
+    Button,
+    Box,
+    Center,
+    Text,
+    Input,
+    FormControl,
+} from "@chakra-ui/react";
+
+/**
+ * This is the page that a user will use to either login or register
+ * to the SDC platform as a parent of volunteer
+ */
+export default function Signupform(): JSX.Element {
+    return (
+        <Center h="500px" margin="10">
+            <Box width="700px">
+                <Center>
+                    <Text fontWeight="700" fontSize="36px" margin="13">
+                        Sign Up
+                    </Text>
+                </Center>
+                <Center>
+                    <Text fontWeight="400" fontSize="18px" mt="18px">
+                        I am a ...
+                    </Text>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="transparent"
+                        borderColor="brand.400"
+                        width="366px"
+                        height="54px"
+                        fontSize="16px"
+                        fontWeight="400"
+                        border="1px"
+                        mt="20px"
+                    >
+                        Parent
+                    </Button>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="transparent"
+                        borderColor="brand.400"
+                        width="366px"
+                        height="54px"
+                        fontSize="16px"
+                        fontWeight="400"
+                        border="1px"
+                        mt="20px"
+                        marginBottom="70"
+                    >
+                        Volunteer
+                    </Button>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="brand.500"
+                        color="brand.100"
+                        width="366px"
+                        height="44px"
+                        fontSize="14px"
+                        fontWeight="400"
+                        mt="20px"
+                        padding="5"
+                        marginTop="100"
+                    >
+                        Next
+                    </Button>
+                </Center>
+            </Box>
+        </Center>
+    );
+}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -13,10 +13,10 @@ import {
  */
 export default function Signupform(): JSX.Element {
     return (
-        <Center h="500px" margin="10">
+        <Center h="500px" margin="10px">
             <Box width="700px">
                 <Center>
-                    <Text fontWeight="700" fontSize="36px" margin="13">
+                    <Text fontWeight="700" fontSize="36px" margin="13px">
                         Sign Up
                     </Text>
                 </Center>
@@ -49,7 +49,7 @@ export default function Signupform(): JSX.Element {
                         fontWeight="400"
                         border="1px"
                         mt="20px"
-                        marginBottom="70"
+                        marginBottom="70px"
                     >
                         Volunteer
                     </Button>
@@ -63,8 +63,8 @@ export default function Signupform(): JSX.Element {
                         fontSize="14px"
                         fontWeight="400"
                         mt="20px"
-                        padding="5"
-                        marginTop="100"
+                        padding="5px"
+                        marginTop="100px"
                     >
                         Next
                     </Button>

--- a/pages/signupform.tsx
+++ b/pages/signupform.tsx
@@ -1,0 +1,74 @@
+import {
+    Button,
+    Box,
+    Center,
+    Text,
+    Input,
+    FormControl,
+} from "@chakra-ui/react";
+
+/**
+ * This is the page that a user will use to either login or register
+ * to the SDC platform as a parent of volunteer
+ */
+export default function Signupform(): JSX.Element {
+    return (
+        <Center h="500px">
+            <Box width="700px">
+                <Center>
+                    <Text fontWeight="700" fontSize="36px">
+                        Sign Up
+                    </Text>
+                </Center>
+                <Center>
+                    <Text fontWeight="400" fontSize="18px" mt="18px">
+                        I am a ...
+                    </Text>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="transparent"
+                        borderColor="#8D8D8D"
+                        width="366px"
+                        height="54px"
+                        fontSize="16px"
+                        fontWeight="400"
+                        border="1px"
+                        mt="20px"
+                    >
+                        Parent
+                    </Button>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="transparent"
+                        borderColor="#8D8D8D"
+                        width="366px"
+                        height="54px"
+                        fontSize="16px"
+                        fontWeight="400"
+                        border="1px"
+                        mt="20px"
+                    >
+                        Volunteer
+                    </Button>
+                </Center>
+                <Center>
+                    <Button
+                        backgroundColor="ECECEC"
+                        color="000000"
+                        width="366px"
+                        height="44px"
+                        fontSize="14px"
+                        fontWeight="400"
+                        mt="20px"
+                        pos="absolute"
+                        bottom="-185"
+                    >
+                        Next
+                    </Button>
+                </Center>
+            </Box>
+        </Center>
+    );
+}

--- a/pages/signupform.tsx
+++ b/pages/signupform.tsx
@@ -28,7 +28,7 @@ export default function Signupform(): JSX.Element {
                 <Center>
                     <Button
                         backgroundColor="transparent"
-                        borderColor="#8D8D8D"
+                        borderColor="brand.400"
                         width="366px"
                         height="54px"
                         fontSize="16px"
@@ -42,7 +42,7 @@ export default function Signupform(): JSX.Element {
                 <Center>
                     <Button
                         backgroundColor="transparent"
-                        borderColor="#8D8D8D"
+                        borderColor="brand.400"
                         width="366px"
                         height="54px"
                         fontSize="16px"
@@ -55,15 +55,16 @@ export default function Signupform(): JSX.Element {
                 </Center>
                 <Center>
                     <Button
-                        backgroundColor="ECECEC"
-                        color="000000"
+                        backgroundColor="brand.500"
+                        color="brand.100"
                         width="366px"
                         height="44px"
                         fontSize="14px"
                         fontWeight="400"
                         mt="20px"
-                        pos="absolute"
                         bottom="-185"
+                        top="350"
+                        padding="-10"
                     >
                         Next
                     </Button>

--- a/src/definitions/chakra/theme/index.ts
+++ b/src/definitions/chakra/theme/index.ts
@@ -9,6 +9,8 @@ const theme = extendTheme({
             100: "#000000",
             200: "#FFFFFF",
             300: "#6C6C6C",
+            400: "#8D8D8D",
+            500: "#ECECEC",
         },
     },
 });


### PR DESCRIPTION
Initial Signup Form
https://www.notion.so/uwblueprintexecs/Frontend-Initial-Sign-up-form-ca1f7c0f2d0448ccb7542c43de8c8d0a

Added initial signup form where user decides if they are a parent or user

Steps to test

Run the app locally and head over to http://localhost:3000/en/signupform to see the new page
  My PR name is descriptive and in imperative tense
  I have run the linter
  I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR