### PR TITLE
Add Functionality For Automatically Applying Coupons

### DIFF
--- a/models/StripeCheckout.ts
+++ b/models/StripeCheckout.ts
@@ -4,5 +4,6 @@
  */
 export type StripeCheckoutRequest = {
     priceId: string;
+    couponId?: string;
     quantity: number;
 };

--- a/pages/api/checkout/session.ts
+++ b/pages/api/checkout/session.ts
@@ -30,29 +30,21 @@ export default async function sessionHandler(
                 allow_promotion_codes: true,
             };
 
-            // if a coupon ID is not passed in then allow promotion codes to be entered
-            if (!stripeRequest.couponId) {
-                const session = await stripe.checkout.sessions.create(
-                    stripeSession,
-                );
-
-                res.status(200).json({ sessionId: session.id });
-            }
-            // otherwise apply the discount from the coupon ID passed in
-            else {
+            // if a coupon ID is passed in then allow use it to apply a discount
+            if (stripeRequest.couponId) {
                 delete stripeSession["allow_promotion_codes"];
                 stripeSession["discounts"] = [
                     {
                         coupon: stripeRequest.couponId,
                     },
                 ];
-
-                const session = await stripe.checkout.sessions.create(
-                    stripeSession,
-                );
-
-                res.status(200).json({ sessionId: session.id });
             }
+
+            const session = await stripe.checkout.sessions.create(
+                stripeSession,
+            );
+
+            res.status(200).json({ sessionId: session.id });
             break;
         }
         default: {

--- a/pages/api/checkout/session.ts
+++ b/pages/api/checkout/session.ts
@@ -16,21 +16,46 @@ export default async function sessionHandler(
     switch (req.method) {
         case "POST": {
             const stripeRequest = req.body as StripeCheckoutRequest;
-            const session = await stripe.checkout.sessions.create({
-                payment_method_types: ["card"],
-                line_items: [
-                    {
-                        price: stripeRequest.priceId,
-                        quantity: stripeRequest.quantity,
-                    },
-                ],
-                mode: "payment",
-                success_url: `${req.headers.origin}/result?session_id={CHECKOUT_SESSION_ID}`,
-                cancel_url: `${req.headers.origin}/checkout`,
-                allow_promotion_codes: true,
-            });
+            // if a coupon ID is passed in then apply an automatic discount
+            if (stripeRequest.couponId) {
+                const session = await stripe.checkout.sessions.create({
+                    payment_method_types: ["card"],
+                    line_items: [
+                        {
+                            price: stripeRequest.priceId,
+                            quantity: stripeRequest.quantity,
+                        },
+                    ],
+                    mode: "payment",
+                    success_url: `${req.headers.origin}/result?session_id={CHECKOUT_SESSION_ID}`,
+                    cancel_url: `${req.headers.origin}/checkout`,
+                    discounts: [
+                        {
+                            coupon: stripeRequest.couponId,
+                        },
+                    ],
+                });
 
-            res.status(200).json({ sessionId: session.id });
+                res.status(200).json({ sessionId: session.id });
+            }
+            // otherwise allow promotion codes to be entered
+            else {
+                const session = await stripe.checkout.sessions.create({
+                    payment_method_types: ["card"],
+                    line_items: [
+                        {
+                            price: stripeRequest.priceId,
+                            quantity: stripeRequest.quantity,
+                        },
+                    ],
+                    mode: "payment",
+                    success_url: `${req.headers.origin}/result?session_id={CHECKOUT_SESSION_ID}`,
+                    cancel_url: `${req.headers.origin}/checkout`,
+                    allow_promotion_codes: true,
+                });
+
+                res.status(200).json({ sessionId: session.id });
+            }
             break;
         }
         default: {

--- a/pages/api/checkout/session.ts
+++ b/pages/api/checkout/session.ts
@@ -38,7 +38,7 @@ export default async function sessionHandler(
 
                 res.status(200).json({ sessionId: session.id });
             }
-            // otherwise apply a default discount
+            // otherwise apply the discount from the coupon ID passed in
             else {
                 delete stripeSession["allow_promotion_codes"];
                 stripeSession["discounts"] = [

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -6,6 +6,9 @@ const testPriceId = "price_1J1GuzL97YpjuvTOePyVbsRh";
 // test quantity to specify number of products
 const testQuantity = 1;
 
+// uncomment to test automatic coupon discounts
+// const testCouponId = "3R69NQNw";
+
 /**
  * This is a test page to test the Checkout Button Component
  * TODO: delete this page once the checkout button is consumed in
@@ -14,7 +17,11 @@ const testQuantity = 1;
 export default function Checkout(): JSX.Element {
     return (
         <div>
-            <CheckoutButton priceId={testPriceId} quantity={testQuantity} />
+            <CheckoutButton
+                priceId={testPriceId}
+                quantity={testQuantity}
+                // couponId={testCouponId}
+            />
         </div>
     );
 }

--- a/services/stripe/index.tsx
+++ b/services/stripe/index.tsx
@@ -5,4 +5,4 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
     apiVersion: "2020-08-27",
 });
 
-export { stripe };
+export { stripe, Stripe };

--- a/src/components/CheckoutButton.tsx
+++ b/src/components/CheckoutButton.tsx
@@ -10,6 +10,7 @@ const stripePromise = loadStripe(
 
 type CheckoutButtonProps = {
     priceId: string;
+    couponId?: string;
     quantity: number;
 };
 
@@ -28,6 +29,7 @@ export const CheckoutButton: React.FC<CheckoutButtonProps> = (
             },
             body: JSON.stringify({
                 priceId: props.priceId,
+                couponId: props.couponId,
                 quantity: props.quantity,
             }),
         }).then((res) => res.json());


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[[BACKEND] Allow Automatic Discounts To Be Applied In Stripe](https://www.notion.so/uwblueprintexecs/BACKEND-Allow-Automatic-Discounts-To-Be-Applied-In-Stripe-9d0c222464e944b7ba1f4b4e9791c3ac)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description
- Added functionality to automatically apply a coupon if a `couponId` is passed in

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
