### PR TITLE
Update styling for proof of income page

### DIFF
--- a/pages/participant-info.tsx
+++ b/pages/participant-info.tsx
@@ -802,8 +802,10 @@ export default function ParticipantInfo({
                         fontSize="16px"
                         fontWeight="400"
                     >
-                        {PROOF_OF_INCOME_EXAMPLES.map((poi) => (
-                            <ListItem mx="20px">{poi}</ListItem>
+                        {PROOF_OF_INCOME_EXAMPLES.map((poi, idx) => (
+                            <ListItem key={idx} mx="20px">
+                                {poi}
+                            </ListItem>
                         ))}
                     </UnorderedList>
                     <br />
@@ -812,8 +814,10 @@ export default function ParticipantInfo({
                     </Heading>
                     <br />
                     <OrderedList margin="10px" fontSize="16px" fontWeight="400">
-                        {UPLOADING_PROOF_OF_INCOME.map((poi) => (
-                            <ListItem mx="20px">{poi}</ListItem>
+                        {UPLOADING_PROOF_OF_INCOME.map((poi, idx) => (
+                            <ListItem key={idx} mx="20px">
+                                {poi}
+                            </ListItem>
                         ))}
                     </OrderedList>
                 </Box>

--- a/pages/participant-info.tsx
+++ b/pages/participant-info.tsx
@@ -45,6 +45,16 @@ const RADIO_NO = "no";
 const DEFAULT_PROVINCE = province.BC;
 // TODO: Checkboxes have bugs in them; sometimes render sometimes don't
 
+const PROOF_OF_INCOME_EXAMPLES = ["Income tax notice", "Paystub", "etc"];
+
+const UPLOADING_PROOF_OF_INCOME = [
+    `Navigate to My Account > Proof of Income`,
+    `Upload a copy of the result to your SDC account`,
+    `Once you’ve submitted your proof of income, keep an eye out for approval status from SDC!`,
+    `Upon approval, discounts will automatically applied to your account!
+    Check your account for details on the amount of discount you have been approved for`,
+];
+
 const FormButton = (props) => {
     return (
         <Button
@@ -242,7 +252,6 @@ export default function ParticipantInfo({
         "Participant Emergency Form",
         "Participant Health Form",
         "Parent Guardian Information",
-        "Confirm Participants",
         "Proof of Income",
         "How did you hear about us?",
     ];
@@ -780,47 +789,33 @@ export default function ParticipantInfo({
         <Box>
             <FormPage>
                 <Box maxW="55rem">
-                    <Text margin="10px" fontSize="16px" fontWeight="200">
+                    <Text fontSize="16px" fontWeight="200" mb="60px">
                         Upload a Proof of Income to recieve automated discounts
                         on classes you take!
                     </Text>
-                    <Heading fontSize="22px">
-                        Example of Proof of income include
-                        <UnorderedList
-                            margin="10px"
-                            fontSize="16px"
-                            fontWeight="400"
-                        >
-                            <ListItem>Income tax notice</ListItem>
-                            <ListItem>Paystub</ListItem>
-                            <ListItem>etc</ListItem>
-                        </UnorderedList>
+                    <Heading fontSize="22px" fontWeight="900">
+                        Examples of Proof of Income Include
                     </Heading>
-                    <Heading fontSize="22px">
+                    <br />
+                    <UnorderedList
+                        margin="10px"
+                        fontSize="16px"
+                        fontWeight="400"
+                    >
+                        {PROOF_OF_INCOME_EXAMPLES.map((poi) => (
+                            <ListItem mx="20px">{poi}</ListItem>
+                        ))}
+                    </UnorderedList>
+                    <br />
+                    <Heading fontSize="22px" fontWeight="900">
                         Uploading your Proof of Income
-                        <OrderedList
-                            margin="10px"
-                            fontSize="16px"
-                            fontWeight="400"
-                        >
-                            <ListItem>
-                                Navigate to My Account, Proof of Income
-                            </ListItem>
-                            <ListItem>
-                                Upload a copy of the result to your SDC account
-                            </ListItem>
-                            <ListItem>
-                                Once you’ve submitted your proof of income, keep
-                                an eye out for approval status from SDC!
-                            </ListItem>
-                            <ListItem>
-                                Upon approval, discounts will automatically
-                                applied to your account! Check your account for
-                                details on the amount of discount you have been
-                                approved for
-                            </ListItem>
-                        </OrderedList>
                     </Heading>
+                    <br />
+                    <OrderedList margin="10px" fontSize="16px" fontWeight="400">
+                        {UPLOADING_PROOF_OF_INCOME.map((poi) => (
+                            <ListItem mx="20px">{poi}</ListItem>
+                        ))}
+                    </OrderedList>
                 </Box>
             </FormPage>
             <Box>

--- a/src/definitions/chakra/theme/index.ts
+++ b/src/definitions/chakra/theme/index.ts
@@ -2,6 +2,7 @@ import { extendTheme } from "@chakra-ui/react";
 
 const theme = extendTheme({
     fonts: {
+        heading: "Poppins",
         body: "Poppins",
     },
     colors: {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/086c1b564dbf478faa649a8880e34b81?v=9d3f8002a0d1477ba395616dfc082af7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Updated styling for the proof of income page to match the Figma designs

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go to http://localhost:3000/en/participant-info and click on the blue "Next" button until the proof of income page is reached

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Style compared to the Figma

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [ ] I have run the linter
-   [ ] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR

![image](https://user-images.githubusercontent.com/42329517/130861102-bf5efc82-d532-49dc-a2cd-d0e559bba04a.png)

Full page including navbar + footer:
![image](https://user-images.githubusercontent.com/42329517/130861235-067f6730-4fda-47a8-a206-484a318dee08.png)
