### PR TITLE
feat(seeding): add sample seeding for prod and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ heroku pg:psql -a YOUR_APP_NAME -f prisma/schema.sql
 
 # Regenerate Prisma schema and client
 npx prisma introspect && npx prisma generate
+
+# Seed your database with sample data
+npx ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts
 ```
 
 To run the application:

--- a/README.md
+++ b/README.md
@@ -34,18 +34,36 @@ Developers: Jason Huang, Soha Khan, Cindy Wang, Brandon Wong, Victor Yun, Mahad 
 ├── .github
 │   ├── workflows/ci.yml # Github workflow
 │   └── pull_request_template.md # PR template
+│
 ├── pages # Pages
 │   ├── _app.tsx
 │   ├── api # API routes
 │   └── index.tsx
+│
 ├── prisma # Prisma ORM
 │   └── schema.prisma # Prisma Schema
+│
 ├── public
 │   ├── icons # Icons
 │   └── locales # Translations
+│
+├── models # Typescript types
+│
 ├── src # Frontend tools
 │   ├── components # Components
 │   └── definitions # Chakra
+│   └── styles # CSS and Colours
+│
+├── utils # Utility functions
+│   └── validation # Data/Input Validators
+│
+├── services # Third party services
+│   ├── auth
+│   ├── aws
+│   ├── database
+│   ├── nodemailer
+│   └── stripe
+│
 # Misc individual files
 ├── .babelrc
 ├── .eslintignore
@@ -62,6 +80,12 @@ Developers: Jason Huang, Soha Khan, Cindy Wang, Brandon Wong, Victor Yun, Mahad 
 ├── tsconfig.json
 └── yarn.lock
 ```
+
+## Local Dependencies
+
+1. [Heroku Client](https://devcenter.heroku.com/articles/heroku-cli)
+2. [NPM](https://nodejs.org/en/download/)
+3. [Yarn](https://classic.yarnpkg.com/en/docs/install)
 
 ## Run Locally
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "fix:prettier": "prettier --write '*.{js,jsx,ts,tsx}'",
         "fix:eslint": "eslint '*.{js,jsx,ts,tsx}' --format stylish --fix"
     },
+    "prisma": {
+        "seed": "ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts"
+    },
     "dependencies": {
         "@chakra-ui/icons": "^1.0.14",
         "@chakra-ui/react": "^1.1.4",
@@ -56,6 +59,7 @@
         "lint-staged": "^10.5.3",
         "prisma": "^2.25.0",
         "style-loader": "^2.0.0",
+        "ts-node": "^10.2.1",
         "typescript": "^4.1.3"
     },
     "husky": {

--- a/prisma/dev-seeds/class-translation.ts
+++ b/prisma/dev-seeds/class-translation.ts
@@ -1,0 +1,53 @@
+import { locale } from ".prisma/client";
+import { ClassTranslation } from "@prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed class translation data
+const classTranslations: ClassTranslation[] = [
+    {
+        classId: 1,
+        name: "Singing Monkeys",
+        description:
+            "Children with special needs will be able to connect with the music teacher through an online video call to socialize and have fun while learning about music!",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        classId: 2,
+        name: "Singing Giraffes",
+        description:
+            "Children with special needs will be able to connect with the music teacher through an online video call to socialize and have fun while learning about music!",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert class translations
+ * @param data custom data to upsert
+ */
+export default async function classTranslationsUpsert(
+    data?: ClassTranslation[],
+): Promise<void> {
+    for (const translation of data || classTranslations) {
+        const { classId, language, createdAt, updatedAt, ...rest } =
+            translation;
+        await prisma.classTranslation
+            .upsert({
+                where: {
+                    classId_language: { classId, language },
+                },
+                update: rest,
+                create: {
+                    classId,
+                    language,
+                    createdAt,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/dev-seeds/class.ts
+++ b/prisma/dev-seeds/class.ts
@@ -51,17 +51,18 @@ const classes: Class[] = [
 export default async function classUpsert(data?: Class[]): Promise<void> {
     for (const classRecord of data || classes) {
         const { id, updatedAt, ...rest } = classRecord;
-        const classUpsert = await prisma.class.upsert({
-            where: {
-                id,
-            },
-            update: rest,
-            create: {
-                id,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ classUpsert });
+        await prisma.class
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/dev-seeds/class.ts
+++ b/prisma/dev-seeds/class.ts
@@ -1,0 +1,67 @@
+import { Class, weekday } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed class data
+const classes: Class[] = [
+    {
+        id: 1,
+        name: "Singing Monkeys",
+        ageGroup: "9 and under",
+        imageLink: "https://media0.giphy.com/media/dNgK7Ws7y176U/giphy_s.gif",
+        programId: 1,
+        spaceTotal: 10,
+        spaceAvailable: 10,
+        volunteerSpaceTotal: 2,
+        volunteerSpaceAvailable: 2,
+        isArchived: false,
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        weekday: weekday.WED,
+        startTimeMinutes: 1080,
+        durationMinutes: 60,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        id: 2,
+        name: "Singing Giraffes",
+        ageGroup: "10 and above",
+        imageLink:
+            "https://media4.giphy.com/media/8OGIYNULdLNOE/giphy.gif?cid=ecf05e471dv24mebe5hsbyyuk9af2jnztcvo484u3r71911r&rid=giphy.gif&ct=g",
+        programId: 1,
+        spaceTotal: 10,
+        spaceAvailable: 10,
+        volunteerSpaceTotal: 2,
+        volunteerSpaceAvailable: 2,
+        isArchived: false,
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        weekday: weekday.THU,
+        startTimeMinutes: 1080,
+        durationMinutes: 60,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert classes
+ * @param data custom data to upsert
+ */
+export default async function classUpsert(data?: Class[]): Promise<void> {
+    for (const classRecord of data || classes) {
+        const { id, updatedAt, ...rest } = classRecord;
+        const classUpsert = await prisma.class.upsert({
+            where: {
+                id,
+            },
+            update: rest,
+            create: {
+                id,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ classUpsert });
+    }
+}

--- a/prisma/dev-seeds/index.ts
+++ b/prisma/dev-seeds/index.ts
@@ -1,0 +1,12 @@
+import classUpsert from "./class";
+import programUpsert from "./program";
+import programTranslationsUpsert from "./program-translation";
+
+/**
+ * Seed the Development environment
+ */
+export default async function seedDev(): Promise<void> {
+    await programUpsert();
+    await programTranslationsUpsert();
+    await classUpsert();
+}

--- a/prisma/dev-seeds/index.ts
+++ b/prisma/dev-seeds/index.ts
@@ -1,6 +1,9 @@
 import classUpsert from "./class";
 import programUpsert from "./program";
 import programTranslationsUpsert from "./program-translation";
+import teacherUpsert from "./teacher";
+import teacherRegUpsert from "./teacher-reg";
+import userUpsert from "./user";
 
 /**
  * Seed the Development environment
@@ -9,4 +12,7 @@ export default async function seedDev(): Promise<void> {
     await programUpsert();
     await programTranslationsUpsert();
     await classUpsert();
+    await userUpsert();
+    await teacherUpsert();
+    await teacherRegUpsert();
 }

--- a/prisma/dev-seeds/index.ts
+++ b/prisma/dev-seeds/index.ts
@@ -1,4 +1,5 @@
 import classUpsert from "./class";
+import classTranslationsUpsert from "./class-translation";
 import programUpsert from "./program";
 import programTranslationsUpsert from "./program-translation";
 import teacherUpsert from "./teacher";
@@ -12,6 +13,7 @@ export default async function seedDev(): Promise<void> {
     await programUpsert();
     await programTranslationsUpsert();
     await classUpsert();
+    await classTranslationsUpsert();
     await userUpsert();
     await teacherUpsert();
     await teacherRegUpsert();

--- a/prisma/dev-seeds/program-translation.ts
+++ b/prisma/dev-seeds/program-translation.ts
@@ -33,19 +33,20 @@ export default async function programTranslationsUpsert(
     for (const translation of data || programTranslations) {
         const { programId, language, createdAt, updatedAt, ...rest } =
             translation;
-        const translationUpsert = await prisma.programTranslation.upsert({
-            where: {
-                programId_language: { programId, language },
-            },
-            update: rest,
-            create: {
-                programId,
-                language,
-                createdAt,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ translationUpsert });
+        await prisma.programTranslation
+            .upsert({
+                where: {
+                    programId_language: { programId, language },
+                },
+                update: rest,
+                create: {
+                    programId,
+                    language,
+                    createdAt,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/dev-seeds/program-translation.ts
+++ b/prisma/dev-seeds/program-translation.ts
@@ -1,0 +1,51 @@
+import { locale, ProgramTranslation } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed program translation data
+const programTranslations: ProgramTranslation[] = [
+    {
+        programId: 1,
+        name: "Building Bridges with Music",
+        description:
+            "Building Bridges with Music is a music program where children with special needs will be able to connect with the music teacher through weekly class sessions to socialize and have fun while learning about music! This program will provide a safe environment for children to participate in interactive activities and build strong relationships during these unprecedented times! We will be offering both in-person and online options for this program in the Fall 2021 semester.",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        programId: 2,
+        name: "Education Through Creativity",
+        description:
+            "Education Through Creativity  is an art program where children with special needs will be guided to develop their social skills and learn to communicate their thoughts and emotions through art. Led by an experienced art teacher, children will be able to build lasting friendships, learn more about expression, and partake in fun interactive activities while enjoying the beauty of art! We will be offering both in-person and online options for this program in the Fall 2021 semester.",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert program translations
+ * @param data custom data to upsert
+ */
+export default async function programTranslationsUpsert(
+    data?: ProgramTranslation[],
+): Promise<void> {
+    for (const translation of data || programTranslations) {
+        const { programId, language, createdAt, updatedAt, ...rest } =
+            translation;
+        const translationUpsert = await prisma.programTranslation.upsert({
+            where: {
+                programId_language: { programId, language },
+            },
+            update: rest,
+            create: {
+                programId,
+                language,
+                createdAt,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ translationUpsert });
+    }
+}

--- a/prisma/dev-seeds/program.ts
+++ b/prisma/dev-seeds/program.ts
@@ -18,7 +18,7 @@ const programs: Program[] = [
     },
     {
         id: 2,
-        price: 0,
+        price: 4,
         onlineFormat: programFormat.online,
         tag: "Art",
         imageLink:
@@ -38,17 +38,18 @@ const programs: Program[] = [
 export default async function programUpsert(data?: Program[]): Promise<void> {
     for (const program of data || programs) {
         const { id, updatedAt, ...rest } = program;
-        const programUpsert = await prisma.program.upsert({
-            where: {
-                id,
-            },
-            update: rest,
-            create: {
-                id,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ programUpsert });
+        await prisma.program
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/dev-seeds/program.ts
+++ b/prisma/dev-seeds/program.ts
@@ -1,0 +1,54 @@
+import { Program, programFormat } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed program data
+const programs: Program[] = [
+    {
+        id: 1,
+        price: 0,
+        onlineFormat: programFormat.online,
+        tag: "Music",
+        imageLink:
+            "https://images.squarespace-cdn.com/content/v1/5e83092341f99d6d384777ef/1608341017251-K0Q0U7BC37SQ5BGCV9G0/IMG_6646.jpg?format=750w",
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        id: 2,
+        price: 0,
+        onlineFormat: programFormat.online,
+        tag: "Art",
+        imageLink:
+            "https://images.squarespace-cdn.com/content/v1/5e83092341f99d6d384777ef/1608341093598-U3AGJCLP1UHUPZJNTYBY/IMG_2791.jpg?format=750w",
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert programs
+ * @param data custom data to upsert
+ */
+export default async function programUpsert(data?: Program[]): Promise<void> {
+    for (const program of data || programs) {
+        const { id, updatedAt, ...rest } = program;
+        const programUpsert = await prisma.program.upsert({
+            where: {
+                id,
+            },
+            update: rest,
+            create: {
+                id,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ programUpsert });
+    }
+}

--- a/prisma/dev-seeds/teacher-reg.ts
+++ b/prisma/dev-seeds/teacher-reg.ts
@@ -1,0 +1,44 @@
+import { TeacherReg } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed teacher registrations data
+const teacherRegs: TeacherReg[] = [
+    {
+        teacherId: 1,
+        classId: 1,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        teacherId: 1,
+        classId: 2,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert teachers registrations
+ * @param data custom data to upsert
+ */
+export default async function teacherRegUpsert(
+    data?: TeacherReg[],
+): Promise<void> {
+    for (const teacherReg of data || teacherRegs) {
+        const { teacherId, classId, updatedAt, ...rest } = teacherReg;
+        await prisma.teacherReg
+            .upsert({
+                where: {
+                    classId_teacherId: { classId, teacherId },
+                },
+                update: rest,
+                create: {
+                    teacherId,
+                    classId,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/dev-seeds/teacher.ts
+++ b/prisma/dev-seeds/teacher.ts
@@ -1,0 +1,34 @@
+import { Teacher } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed teacher data
+const teachers: Teacher[] = [
+    {
+        id: 1,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert teachers
+ * @param data custom data to upsert
+ */
+export default async function teacherUpsert(data?: Teacher[]): Promise<void> {
+    for (const teacher of data || teachers) {
+        const { id, updatedAt, ...rest } = teacher;
+        await prisma.teacher
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/dev-seeds/user.ts
+++ b/prisma/dev-seeds/user.ts
@@ -1,0 +1,40 @@
+import { roles, User } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed user data
+const users: User[] = [
+    {
+        id: 1,
+        firstName: "Rickson",
+        lastName: "Yang",
+        email: "ricksonyang+teacher@uwblueprint.org",
+        emailVerified: new Date(),
+        role: roles.TEACHER,
+        image: "https://lh3.googleusercontent.com/fife/AAWUweVbAMrzMwjvDOdWQCcXropikyf3TaxEEMvtPNcyxdAmHO_TUGOCaAZwSPGZMcLch4T8AWiEC3MOFNLXhkfrs60VB3igUn00IwY7K1Aa1tZKvi-kc2sRwq9u7gmRaMjJ9PyyLdhXYFAOWphrXLD10NLYb_wZBSUymKNNfVBjT5ieCddAfH84ffI1wdDjQjKHmq5jM0BSPh0pKM41PwuDcXYeEJ82GFNmjvmf9O-w1X2TbcnTp5qqeEcEJz51rZleAMXNpw4mf2Rf7S_PXbrNwrc4rWJn6_YORn-I5gcnm1O8smSUAgdUF7FQxlMiLg0D6yjjuJYQA2mgEmW1Ox6kizyVh5g6ufPCAPoFIHqBATjVxB4UwZgEGKP5jLydzIYHvDHdMGEayLh0BWMiXD3c1r10DRIUVfjOW0zv-FdecEQvMeOV4NJcKDHTWy1p-IKeGl34vyT3uWJ-j2uCF--Vb4kDOKyqvJ18DwtVmAoX21BoKGz8YjINy2d2BshlYzBbxIzxn3NxBh3hPZ_4G9iLjtXmcbwTsOe60c6EbY9jLEXjiwdWY7fYZU81Wj93e79IzPoM2lckCqRkjUv7XYm0-sC19MSy-Z5OVsZCbm-7LD-jd9VpqQzIn1L3T8ndL2lZlWM-_-yAhJPlH6QSWOoLx-J5gxB9GYym0JVWdphdCwdCzB2bO7SUo39IHFRvdAlJWlr1h4El-9-JtlulBDi0rre8JJRDJL1avyIZYMpqJa3W3Q=s83-c",
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert users
+ * @param data custom data to upsert
+ */
+export default async function userUpsert(data?: User[]): Promise<void> {
+    for (const user of data || users) {
+        const { id, updatedAt, ...rest } = user;
+        await prisma.user
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/prod-seeds/class-translation.ts
+++ b/prisma/prod-seeds/class-translation.ts
@@ -1,0 +1,53 @@
+import { locale } from ".prisma/client";
+import { ClassTranslation } from "@prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed class translation data
+const classTranslations: ClassTranslation[] = [
+    {
+        classId: 1,
+        name: "Singing Monkeys",
+        description:
+            "Children with special needs will be able to connect with the music teacher through an online video call to socialize and have fun while learning about music!",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        classId: 2,
+        name: "Singing Giraffes",
+        description:
+            "Children with special needs will be able to connect with the music teacher through an online video call to socialize and have fun while learning about music!",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert class translations
+ * @param data custom data to upsert
+ */
+export default async function classTranslationsUpsert(
+    data?: ClassTranslation[],
+): Promise<void> {
+    for (const translation of data || classTranslations) {
+        const { classId, language, createdAt, updatedAt, ...rest } =
+            translation;
+        await prisma.classTranslation
+            .upsert({
+                where: {
+                    classId_language: { classId, language },
+                },
+                update: rest,
+                create: {
+                    classId,
+                    language,
+                    createdAt,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/prod-seeds/class.ts
+++ b/prisma/prod-seeds/class.ts
@@ -51,17 +51,18 @@ const classes: Class[] = [
 export default async function classUpsert(data?: Class[]): Promise<void> {
     for (const classRecord of data || classes) {
         const { id, updatedAt, ...rest } = classRecord;
-        const classUpsert = await prisma.class.upsert({
-            where: {
-                id,
-            },
-            update: rest,
-            create: {
-                id,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ classUpsert });
+        await prisma.class
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/prod-seeds/class.ts
+++ b/prisma/prod-seeds/class.ts
@@ -1,0 +1,67 @@
+import { Class, weekday } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed class data
+const classes: Class[] = [
+    {
+        id: 1,
+        name: "Singing Monkeys",
+        ageGroup: "9 and under",
+        imageLink: "https://media0.giphy.com/media/dNgK7Ws7y176U/giphy_s.gif",
+        programId: 1,
+        spaceTotal: 10,
+        spaceAvailable: 10,
+        volunteerSpaceTotal: 2,
+        volunteerSpaceAvailable: 2,
+        isArchived: false,
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        weekday: weekday.WED,
+        startTimeMinutes: 1080,
+        durationMinutes: 60,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        id: 2,
+        name: "Singing Giraffes",
+        ageGroup: "10 and above",
+        imageLink:
+            "https://media4.giphy.com/media/8OGIYNULdLNOE/giphy.gif?cid=ecf05e471dv24mebe5hsbyyuk9af2jnztcvo484u3r71911r&rid=giphy.gif&ct=g",
+        programId: 1,
+        spaceTotal: 10,
+        spaceAvailable: 10,
+        volunteerSpaceTotal: 2,
+        volunteerSpaceAvailable: 2,
+        isArchived: false,
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        weekday: weekday.THU,
+        startTimeMinutes: 1080,
+        durationMinutes: 60,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert classes
+ * @param data custom data to upsert
+ */
+export default async function classUpsert(data?: Class[]): Promise<void> {
+    for (const classRecord of data || classes) {
+        const { id, updatedAt, ...rest } = classRecord;
+        const classUpsert = await prisma.class.upsert({
+            where: {
+                id,
+            },
+            update: rest,
+            create: {
+                id,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ classUpsert });
+    }
+}

--- a/prisma/prod-seeds/index.ts
+++ b/prisma/prod-seeds/index.ts
@@ -1,6 +1,9 @@
 import classUpsert from "./class";
 import programUpsert from "./program";
 import programTranslationsUpsert from "./program-translation";
+import teacherUpsert from "./teacher";
+import teacherRegUpsert from "./teacher-reg";
+import userUpsert from "./user";
 
 /**
  * Seed the Production environment
@@ -9,4 +12,7 @@ export default async function seedProd(): Promise<void> {
     await programUpsert();
     await programTranslationsUpsert();
     await classUpsert();
+    await userUpsert();
+    await teacherUpsert();
+    await teacherRegUpsert();
 }

--- a/prisma/prod-seeds/index.ts
+++ b/prisma/prod-seeds/index.ts
@@ -1,0 +1,12 @@
+import classUpsert from "./class";
+import programUpsert from "./program";
+import programTranslationsUpsert from "./program-translation";
+
+/**
+ * Seed the Production environment
+ */
+export default async function seedProd(): Promise<void> {
+    await programUpsert();
+    await programTranslationsUpsert();
+    await classUpsert();
+}

--- a/prisma/prod-seeds/index.ts
+++ b/prisma/prod-seeds/index.ts
@@ -1,4 +1,5 @@
 import classUpsert from "./class";
+import classTranslationsUpsert from "./class-translation";
 import programUpsert from "./program";
 import programTranslationsUpsert from "./program-translation";
 import teacherUpsert from "./teacher";
@@ -12,6 +13,7 @@ export default async function seedProd(): Promise<void> {
     await programUpsert();
     await programTranslationsUpsert();
     await classUpsert();
+    await classTranslationsUpsert();
     await userUpsert();
     await teacherUpsert();
     await teacherRegUpsert();

--- a/prisma/prod-seeds/program-translation.ts
+++ b/prisma/prod-seeds/program-translation.ts
@@ -33,19 +33,20 @@ export default async function programTranslationsUpsert(
     for (const translation of data || programTranslations) {
         const { programId, language, createdAt, updatedAt, ...rest } =
             translation;
-        const translationUpsert = await prisma.programTranslation.upsert({
-            where: {
-                programId_language: { programId, language },
-            },
-            update: rest,
-            create: {
-                programId,
-                language,
-                createdAt,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ translationUpsert });
+        await prisma.programTranslation
+            .upsert({
+                where: {
+                    programId_language: { programId, language },
+                },
+                update: rest,
+                create: {
+                    programId,
+                    language,
+                    createdAt,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/prod-seeds/program-translation.ts
+++ b/prisma/prod-seeds/program-translation.ts
@@ -1,0 +1,51 @@
+import { locale, ProgramTranslation } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed program translation data
+const programTranslations: ProgramTranslation[] = [
+    {
+        programId: 1,
+        name: "Building Bridges with Music",
+        description:
+            "Building Bridges with Music is a music program where children with special needs will be able to connect with the music teacher through weekly class sessions to socialize and have fun while learning about music! This program will provide a safe environment for children to participate in interactive activities and build strong relationships during these unprecedented times! We will be offering both in-person and online options for this program in the Fall 2021 semester.",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        programId: 2,
+        name: "Education Through Creativity",
+        description:
+            "Education Through Creativity  is an art program where children with special needs will be guided to develop their social skills and learn to communicate their thoughts and emotions through art. Led by an experienced art teacher, children will be able to build lasting friendships, learn more about expression, and partake in fun interactive activities while enjoying the beauty of art! We will be offering both in-person and online options for this program in the Fall 2021 semester.",
+        language: locale.en,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert program translations
+ * @param data custom data to upsert
+ */
+export default async function programTranslationsUpsert(
+    data?: ProgramTranslation[],
+): Promise<void> {
+    for (const translation of data || programTranslations) {
+        const { programId, language, createdAt, updatedAt, ...rest } =
+            translation;
+        const translationUpsert = await prisma.programTranslation.upsert({
+            where: {
+                programId_language: { programId, language },
+            },
+            update: rest,
+            create: {
+                programId,
+                language,
+                createdAt,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ translationUpsert });
+    }
+}

--- a/prisma/prod-seeds/program.ts
+++ b/prisma/prod-seeds/program.ts
@@ -18,7 +18,7 @@ const programs: Program[] = [
     },
     {
         id: 2,
-        price: 0,
+        price: 4,
         onlineFormat: programFormat.online,
         tag: "Art",
         imageLink:
@@ -38,17 +38,18 @@ const programs: Program[] = [
 export default async function programUpsert(data?: Program[]): Promise<void> {
     for (const program of data || programs) {
         const { id, updatedAt, ...rest } = program;
-        const programUpsert = await prisma.program.upsert({
-            where: {
-                id,
-            },
-            update: rest,
-            create: {
-                id,
-                updatedAt,
-                ...rest,
-            },
-        });
-        console.log({ programUpsert });
+        await prisma.program
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
     }
 }

--- a/prisma/prod-seeds/program.ts
+++ b/prisma/prod-seeds/program.ts
@@ -1,0 +1,54 @@
+import { Program, programFormat } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed program data
+const programs: Program[] = [
+    {
+        id: 1,
+        price: 0,
+        onlineFormat: programFormat.online,
+        tag: "Music",
+        imageLink:
+            "https://images.squarespace-cdn.com/content/v1/5e83092341f99d6d384777ef/1608341017251-K0Q0U7BC37SQ5BGCV9G0/IMG_6646.jpg?format=750w",
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        id: 2,
+        price: 0,
+        onlineFormat: programFormat.online,
+        tag: "Art",
+        imageLink:
+            "https://images.squarespace-cdn.com/content/v1/5e83092341f99d6d384777ef/1608341093598-U3AGJCLP1UHUPZJNTYBY/IMG_2791.jpg?format=750w",
+        startDate: new Date(),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 7)),
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert programs
+ * @param data custom data to upsert
+ */
+export default async function programUpsert(data?: Program[]): Promise<void> {
+    for (const program of data || programs) {
+        const { id, updatedAt, ...rest } = program;
+        const programUpsert = await prisma.program.upsert({
+            where: {
+                id,
+            },
+            update: rest,
+            create: {
+                id,
+                updatedAt,
+                ...rest,
+            },
+        });
+        console.log({ programUpsert });
+    }
+}

--- a/prisma/prod-seeds/teacher-reg.ts
+++ b/prisma/prod-seeds/teacher-reg.ts
@@ -1,0 +1,44 @@
+import { TeacherReg } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed teacher registrations data
+const teacherRegs: TeacherReg[] = [
+    {
+        teacherId: 1,
+        classId: 1,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    {
+        teacherId: 1,
+        classId: 2,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert teachers registrations
+ * @param data custom data to upsert
+ */
+export default async function teacherRegUpsert(
+    data?: TeacherReg[],
+): Promise<void> {
+    for (const teacherReg of data || teacherRegs) {
+        const { teacherId, classId, updatedAt, ...rest } = teacherReg;
+        await prisma.teacherReg
+            .upsert({
+                where: {
+                    classId_teacherId: { classId, teacherId },
+                },
+                update: rest,
+                create: {
+                    teacherId,
+                    classId,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/prod-seeds/teacher.ts
+++ b/prisma/prod-seeds/teacher.ts
@@ -1,0 +1,34 @@
+import { Teacher } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed teacher data
+const teachers: Teacher[] = [
+    {
+        id: 1,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert teachers
+ * @param data custom data to upsert
+ */
+export default async function teacherUpsert(data?: Teacher[]): Promise<void> {
+    for (const teacher of data || teachers) {
+        const { id, updatedAt, ...rest } = teacher;
+        await prisma.teacher
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/prod-seeds/user.ts
+++ b/prisma/prod-seeds/user.ts
@@ -1,0 +1,40 @@
+import { roles, User } from ".prisma/client";
+import prisma from "../../services/database"; // Relative path required, aliases throw error using seed
+
+// Seed user data
+const users: User[] = [
+    {
+        id: 1,
+        firstName: "Rickson",
+        lastName: "Yang",
+        email: "ricksonyang+teacher@uwblueprint.org",
+        emailVerified: new Date(),
+        role: roles.TEACHER,
+        image: "https://lh3.googleusercontent.com/fife/AAWUweVbAMrzMwjvDOdWQCcXropikyf3TaxEEMvtPNcyxdAmHO_TUGOCaAZwSPGZMcLch4T8AWiEC3MOFNLXhkfrs60VB3igUn00IwY7K1Aa1tZKvi-kc2sRwq9u7gmRaMjJ9PyyLdhXYFAOWphrXLD10NLYb_wZBSUymKNNfVBjT5ieCddAfH84ffI1wdDjQjKHmq5jM0BSPh0pKM41PwuDcXYeEJ82GFNmjvmf9O-w1X2TbcnTp5qqeEcEJz51rZleAMXNpw4mf2Rf7S_PXbrNwrc4rWJn6_YORn-I5gcnm1O8smSUAgdUF7FQxlMiLg0D6yjjuJYQA2mgEmW1Ox6kizyVh5g6ufPCAPoFIHqBATjVxB4UwZgEGKP5jLydzIYHvDHdMGEayLh0BWMiXD3c1r10DRIUVfjOW0zv-FdecEQvMeOV4NJcKDHTWy1p-IKeGl34vyT3uWJ-j2uCF--Vb4kDOKyqvJ18DwtVmAoX21BoKGz8YjINy2d2BshlYzBbxIzxn3NxBh3hPZ_4G9iLjtXmcbwTsOe60c6EbY9jLEXjiwdWY7fYZU81Wj93e79IzPoM2lckCqRkjUv7XYm0-sC19MSy-Z5OVsZCbm-7LD-jd9VpqQzIn1L3T8ndL2lZlWM-_-yAhJPlH6QSWOoLx-J5gxB9GYym0JVWdphdCwdCzB2bO7SUo39IHFRvdAlJWlr1h4El-9-JtlulBDi0rre8JJRDJL1avyIZYMpqJa3W3Q=s83-c",
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+];
+
+/**
+ * Upsert users
+ * @param data custom data to upsert
+ */
+export default async function userUpsert(data?: User[]): Promise<void> {
+    for (const user of data || users) {
+        const { id, updatedAt, ...rest } = user;
+        await prisma.user
+            .upsert({
+                where: {
+                    id,
+                },
+                update: rest,
+                create: {
+                    id,
+                    updatedAt,
+                    ...rest,
+                },
+            })
+            .catch((err) => console.log(err));
+    }
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,24 @@
+import seedDev from "./dev-seeds/index";
+import seedProd from "./prod-seeds/index";
+import prisma from "../services/database";
+
+/**
+ * Main method
+ */
+const main = async () => {
+    if (process.env.NODE_ENV === "production") {
+        await seedProd();
+    } else {
+        await seedDev();
+    }
+};
+
+// Execute main to start seeding
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    })
+    .finally(() => {
+        prisma.$disconnect();
+    });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,18 @@
   dependencies:
     "@chakra-ui/utils" "1.8.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
+  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
@@ -1867,21 +1879,21 @@
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
 "@prisma/client@^2.23.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.25.0.tgz#a81cdf93ce93128eb35298cf8935480f3da6cca3"
-  integrity sha512-JDrAJ+oemiYAwgpYNJvCVT59S9bMbqkx78q2OT54xmmBoyYWWnn6t6oS6q8gKMiKHS6rzm/jdh3sy+2E0R+NAQ==
+  version "2.30.3"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.30.3.tgz#49c1015e2cec26a44b20c62eb2fd738cb0bb043b"
+  integrity sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==
   dependencies:
-    "@prisma/engines-version" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+    "@prisma/engines-version" "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
 
-"@prisma/engines-version@2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922":
-  version "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922.tgz#b353576a97d0c1952fd4f4201189e845aaafbea8"
-  integrity sha512-uZaonv3ZzLYAi99AooOe2BOBmb3k+ibVsJyZ5J3F6U1uFHTtTI9AVzC51mE09iNcgq3ZBt2CZNi5CDQZedMWyA==
+"@prisma/engines-version@2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20":
+  version "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz#d5ef55c92beeba56e52bba12b703af0bfd30530d"
+  integrity sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw==
 
-"@prisma/engines@2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922":
-  version "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922.tgz#68d7850d311df6d017e1b878adb19ec21483bcf0"
-  integrity sha512-vjLCk8AFRZu3D8h/SMcWDzTo0xkMuUDyXQzXekn8gzAGjb47B6LQXGR6rDoZ3/uPM13JNTLPvF62mtVaY6fVeQ==
+"@prisma/engines@2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20":
+  version "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz#2df768aa7c9f84acaa1f35c970417822233a9fb1"
+  integrity sha512-WPnA/IUrxDihrRhdP6+8KAVSwsc0zsh8ioPYsLJjOhzVhwpRbuFH2tJDRIAbc+qFh+BbTIZbeyBYt8fpNXaYQQ==
 
 "@reach/alert@0.13.2":
   version "0.13.2"
@@ -2031,6 +2043,26 @@
     cosmiconfig "^7.0.0"
     deepmerge "^4.2.2"
     svgo "^1.2.2"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/body-parser@*":
   version "1.19.0"
@@ -2403,6 +2435,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -2412,6 +2449,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
 adjust-sourcemap-loader@3.0.0:
   version "3.0.0"
@@ -2563,6 +2605,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3464,6 +3511,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
@@ -3770,6 +3822,11 @@ detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5640,6 +5697,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -6723,11 +6785,11 @@ pretty-format@^3.8.0:
   integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 prisma@^2.25.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.25.0.tgz#1ebfef3e945a22c673b3e3c5100f098da475700d"
-  integrity sha512-AdAlP+PShvugljIx62Omu+eLKu6Cozz06dehmClIHSb0/yFiVnyBtrRVV4LZus+QX6Ayg7CTDvtzroACAWl+Zw==
+  version "2.30.3"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.30.3.tgz#e4a770e1f52151e72c1c5be0aa2e75222a0135c4"
+  integrity sha512-48qYba2BIyUmXuosBZs0g3kYGrxKvo4VkSHYOuLlDdDirmKyvoY2hCYMUYHSx3f++8ovfgs+MX5KmNlP+iAZrQ==
   dependencies:
-    "@prisma/engines" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+    "@prisma/engines" "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -8062,6 +8124,24 @@ traverse@0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
+ts-node@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
+  integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.6.1"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -8589,6 +8669,11 @@ yargs@^16.0.0, yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Seeding Database](https://www.notion.so/uwblueprintexecs/Seeding-Database-32402df8657d407285565f2976f4c009)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Add sample seeding for classes, programs, and program translations which refects the records in staging.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Create a new DB URL
2. run `yarn`
2. run the sql script against the DB (using the heroku client)
3. do prisma introspect and generate
4. run `npx ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts` 
5. run `yarn dev` and ensure pages with program are populated

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- content of sample data
- how seeding is done
- style

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
