### PR TITLE
feature - 404 error page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -13,13 +13,13 @@ export default function Custom404(props: ComponentProps): JSX.Element {
 
     return (
         <Wrapper session={props.session}>
-            <Center h="80vh" align="center">
-                <Box align="center" width="60%">
+            <Center minHeight="85vh" align="center">
+                <Box align="center" width="70%">
                     <SvgErrorIcon />
-                    <Heading size="xl" margin="3% 0% 3% 0%">
+                    <Heading size="md" margin="3% 0% 3% 0%">
                         Oh no! Page not found.
                     </Heading>
-                    <Text size="2xl" marginBottom="3%">
+                    <Text size="md" marginBottom="3%">
                         Sorry, but the page you are looking for does not exist.
                         Try refreshing the page or hit the button below.
                     </Text>
@@ -27,8 +27,8 @@ export default function Custom404(props: ComponentProps): JSX.Element {
                         color="white"
                         backgroundColor="#0C53A0"
                         _hover={{ backgroundColor: "#2C6AAD" }}
-                        width="50%"
-                        padding="10px 12px 10px 12px"
+                        size="sm"
+                        padding="10px 40px 10px 40px"
                         onClick={goToHome}
                         borderRadius={100}
                         fontWeight={"200"}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,6 @@
 import Wrapper from "@components/SDCWrapper";
 import SvgErrorIcon from "@components/icons/ErrorIcon";
+import colourTheme from "@styles/colours";
 import { Button, Box, Center, Heading, Text } from "@chakra-ui/react";
 
 type ComponentProps = {
@@ -16,19 +17,22 @@ export default function Custom404(props: ComponentProps): JSX.Element {
             <Center minHeight="85vh" align="center">
                 <Box align="center" width="70%">
                     <SvgErrorIcon />
-                    <Heading size="md" margin="3% 0% 3% 0%">
+                    <Heading size="lg" mt={12}>
                         Oh no! Page not found.
                     </Heading>
-                    <Text size="md" marginBottom="3%">
+                    <Text size="md" my={9}>
                         Sorry, but the page you are looking for does not exist.
                         Try refreshing the page or hit the button below.
                     </Text>
                     <Button
                         color="white"
-                        backgroundColor="#0C53A0"
-                        _hover={{ backgroundColor: "#2C6AAD" }}
+                        backgroundColor={colourTheme.colors.Blue}
+                        _hover={{
+                            backgroundColor: colourTheme.colors.LightBlue,
+                        }}
                         size="sm"
-                        padding="10px 40px 10px 40px"
+                        py={5}
+                        width="50%"
                         onClick={goToHome}
                         borderRadius={100}
                         fontWeight={"200"}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,42 @@
+import Wrapper from "@components/SDCWrapper";
+import SvgErrorIcon from "@components/icons/ErrorIcon";
+import { Button, Box, Center, Heading, Text } from "@chakra-ui/react";
+
+type ComponentProps = {
+    session: Record<string, unknown>;
+};
+
+export default function Custom404(props: ComponentProps): JSX.Element {
+    const goToHome = () => {
+        window.location.href = "/";
+    };
+
+    return (
+        <Wrapper session={props.session}>
+            <Center h="80vh" align="center">
+                <Box align="center" width="60%">
+                    <SvgErrorIcon />
+                    <Heading size="xl" margin="3% 0% 3% 0%">
+                        Oh no! Page not found.
+                    </Heading>
+                    <Text size="2xl" marginBottom="3%">
+                        Sorry, but the page you are looking for does not exist.
+                        Try refreshing the page or hit the button below.
+                    </Text>
+                    <Button
+                        color="white"
+                        backgroundColor="#0C53A0"
+                        _hover={{ backgroundColor: "#2C6AAD" }}
+                        width="50%"
+                        padding="10px 12px 10px 12px"
+                        onClick={goToHome}
+                        borderRadius={100}
+                        fontWeight={"200"}
+                    >
+                        Return to main page
+                    </Button>
+                </Box>
+            </Center>
+        </Wrapper>
+    );
+}

--- a/public/icons/error-icon.svg
+++ b/public/icons/error-icon.svg
@@ -1,0 +1,31 @@
+        <svg
+            width="155"
+            height="155"
+            viewBox="0 0 155 155"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <circle cx="77.5" cy="77.5" r="77.5" fill="#CFD7E0" />
+            <rect
+                x="35.4297"
+                y="97.428"
+                width="11.0149"
+                height="11.0149"
+                rx="5.50744"
+                fill="white"
+            />
+            <rect
+                x="108.129"
+                y="97.428"
+                width="11.0149"
+                height="11.0149"
+                rx="5.50744"
+                fill="white"
+            />
+            <path
+                d="M55.3574 124C55.3574 124 65.6908 117.357 78.6074 117.357C91.5241 117.357 101.857 124 101.857 124"
+                stroke="white"
+                strokeWidth="7"
+                strokeLinecap="round"
+            />
+        </svg>

--- a/public/icons/error-icon.svg
+++ b/public/icons/error-icon.svg
@@ -1,31 +1,31 @@
-        <svg
-            width="155"
-            height="155"
-            viewBox="0 0 155 155"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <circle cx="77.5" cy="77.5" r="77.5" fill="#CFD7E0" />
-            <rect
-                x="35.4297"
-                y="97.428"
-                width="11.0149"
-                height="11.0149"
-                rx="5.50744"
-                fill="white"
-            />
-            <rect
-                x="108.129"
-                y="97.428"
-                width="11.0149"
-                height="11.0149"
-                rx="5.50744"
-                fill="white"
-            />
-            <path
-                d="M55.3574 124C55.3574 124 65.6908 117.357 78.6074 117.357C91.5241 117.357 101.857 124 101.857 124"
-                stroke="white"
-                strokeWidth="7"
-                strokeLinecap="round"
-            />
-        </svg>
+<svg
+    width="155"
+    height="155"
+    viewBox="0 0 155 155"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+>
+    <circle cx="77.5" cy="77.5" r="77.5" fill="#CFD7E0" />
+    <rect
+        x="35.4297"
+        y="97.428"
+        width="11.0149"
+        height="11.0149"
+        rx="5.50744"
+        fill="white"
+    />
+    <rect
+        x="108.129"
+        y="97.428"
+        width="11.0149"
+        height="11.0149"
+        rx="5.50744"
+        fill="white"
+    />
+    <path
+        d="M55.3574 124C55.3574 124 65.6908 117.357 78.6074 117.357C91.5241 117.357 101.857 124 101.857 124"
+        stroke="white"
+        strokeWidth="7"
+        strokeLinecap="round"
+    />
+</svg>

--- a/src/components/icons/ErrorIcon.tsx
+++ b/src/components/icons/ErrorIcon.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+function SvgErrorIcon(props: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            width="155"
+            height="155"
+            viewBox="0 0 155 155"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <circle cx="77.5" cy="77.5" r="77.5" fill="#CFD7E0" />
+            <rect
+                x="35.4297"
+                y="97.428"
+                width="11.0149"
+                height="11.0149"
+                rx="5.50744"
+                fill="white"
+            />
+            <rect
+                x="108.129"
+                y="97.428"
+                width="11.0149"
+                height="11.0149"
+                rx="5.50744"
+                fill="white"
+            />
+            <path
+                d="M55.3574 124C55.3574 124 65.6908 117.357 78.6074 117.357C91.5241 117.357 101.857 124 101.857 124"
+                stroke="white"
+                stroke-width="7"
+                stroke-linecap="round"
+            />
+        </svg>
+    );
+}
+
+export default SvgErrorIcon;

--- a/src/components/icons/ErrorIcon.tsx
+++ b/src/components/icons/ErrorIcon.tsx
@@ -29,8 +29,8 @@ function SvgErrorIcon(props: React.SVGProps<SVGSVGElement>) {
             <path
                 d="M55.3574 124C55.3574 124 65.6908 117.357 78.6074 117.357C91.5241 117.357 101.857 124 101.857 124"
                 stroke="white"
-                stroke-width="7"
-                stroke-linecap="round"
+                strokeWidth="7"
+                strokeLinecap="round"
             />
         </svg>
     );

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,3 +1,4 @@
+export { default as ErrorIcon } from "./ErrorIcon";
 export { default as GithubIcon } from "./GithubIcon";
 export { default as LinkedinIcon } from "./LinkedinIcon";
 export { default as Logo } from "./Logo";


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create 404 Error Page](https://www.notion.so/uwblueprintexecs/Create-404-Error-Page-2c23078e84b1404b9ea288b477764746)

(updated 10/03, this is what it looks like after adding suggestions)
<img width="1440" alt="Screen Shot 2021-10-03 at 5 48 25 PM" src="https://user-images.githubusercontent.com/45214377/135772616-d6deafa3-256b-44e0-9325-7846549207b0.png">

Error page designed according to the [Figma design here](https://www.figma.com/file/ad7RNFErTGP7HkL52edTwQ/SDC-%2F-S21-External-Application?node-id=1563%3A18312)

### Implementation description

- Added `404.tsx` page and also the error icon as a component (`SvgErrorIcon`) as taken from the Figma

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go to an invalid URL
2. Click the button to go back to home

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Let me know if there are any thoughts on styling fixes !

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
