### PR TITLE
Converted All borderRadius Elements to Square

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -31,7 +31,7 @@ export default function Custom404(props: ComponentProps): JSX.Element {
                             size="sm"
                             py={5}
                             width="50%"
-                            borderRadius={100}
+                            borderRadius="6px"
                             fontWeight={"200"}
                         >
                             Return to main page

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -83,7 +83,7 @@ export default function Login(): JSX.Element {
                                 fontWeight="400"
                                 mt="30px"
                                 _hover={{}}
-                                borderRadius={100}
+                                borderRadius="6px"
                             >
                                 Please enter a valid email to continue.
                             </Button>
@@ -98,7 +98,7 @@ export default function Login(): JSX.Element {
                                 _hover={{
                                     bg: "#2C6AAD",
                                 }}
-                                borderRadius={100}
+                                borderRadius="6px"
                                 onClick={() => {
                                     setValue(!value);
                                     setLocalStorageEmail(email);
@@ -118,7 +118,7 @@ export default function Login(): JSX.Element {
                                 fontSize="12px"
                                 fontWeight="400"
                                 mt="20px"
-                                borderRadius={100}
+                                borderRadius="6px"
                             />
                         )}
                     </Center>

--- a/pages/parent/signup.tsx
+++ b/pages/parent/signup.tsx
@@ -44,7 +44,7 @@ const FormButton = (props) => {
             onClick={props.onClick}
             my={8}
             px={12}
-            borderRadius={100}
+            borderRadius="6px"
         >
             {props.children}
         </Button>
@@ -345,7 +345,7 @@ export default function ParticipantInfo({
                         variant="ghost"
                         as="u"
                         onClick={() => setPageNum((prevPage) => prevPage + 1)}
-                        borderRadius={100}
+                        borderRadius="6px"
                     >
                         Skip for Now
                     </Button>

--- a/pages/volunteer/signup.tsx
+++ b/pages/volunteer/signup.tsx
@@ -22,7 +22,7 @@ const FormButton = (props) => {
             onClick={props.onClick}
             my={8}
             px={12}
-            borderRadius={100}
+            borderRadius="6px"
         >
             {props.children}
         </Button>
@@ -141,7 +141,7 @@ export default function VolunteerInfo({
                             setPageNum((prevPage) => prevPage + 1);
                             updateUserAndClearForm();
                         }}
-                        borderRadius={100}
+                        borderRadius="6px"
                     >
                         Skip for Now
                     </Button>

--- a/src/components/EnrollmentCard.tsx
+++ b/src/components/EnrollmentCard.tsx
@@ -116,7 +116,7 @@ export const EnrollmentCard: React.FC<EnrollmentCardProps> = ({
                                 color={"white"}
                                 mx={"auto"}
                                 my={2}
-                                borderRadius={6}
+                                borderRadius="6px"
                                 onClick={() => alert("Joining Zoom meeting...")}
                                 fontWeight={"normal"}
                                 _hover={{

--- a/src/components/LanguageModal.tsx
+++ b/src/components/LanguageModal.tsx
@@ -71,7 +71,7 @@ export const LanguageModal: React.FC<LanguageModalProps> = ({
                             color={"white"}
                             mx={"auto"}
                             my={2}
-                            borderRadius={100}
+                            borderRadius="6px"
                             onClick={() =>
                                 router.push(router.asPath, undefined, {
                                     locale: language,

--- a/src/components/SDCBadge.tsx
+++ b/src/components/SDCBadge.tsx
@@ -10,7 +10,7 @@ type SDCBadgeProps = BadgeProps & { isOff?: boolean };
 export const SDCBadge: React.FC<SDCBadgeProps> = ({ isOff, ...restProps }) => {
     return (
         <Badge
-            borderRadius="full"
+            borderRadius="6px"
             fontWeight="medium"
             letterSpacing="wide"
             textTransform="none"

--- a/src/components/SDCBadge.tsx
+++ b/src/components/SDCBadge.tsx
@@ -10,7 +10,7 @@ type SDCBadgeProps = BadgeProps & { isOff?: boolean };
 export const SDCBadge: React.FC<SDCBadgeProps> = ({ isOff, ...restProps }) => {
     return (
         <Badge
-            borderRadius="6px"
+            borderRadius="full"
             fontWeight="medium"
             letterSpacing="wide"
             textTransform="none"

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -18,7 +18,7 @@ export const SignInButton: React.FC = () => {
                     }}
                     _active={{}}
                     fontWeight={"200"}
-                    borderRadius={100}
+                    borderRadius="6px"
                 >
                     Sign In
                 </Button>

--- a/src/components/VolunteeringCard.tsx
+++ b/src/components/VolunteeringCard.tsx
@@ -98,7 +98,7 @@ export const VolunteeringCard: React.FC<VolunteeringCardProps> = ({
                                 color={"white"}
                                 mx={"auto"}
                                 my={2}
-                                borderRadius={6}
+                                borderRadius="6px"
                                 onClick={() => alert("Joining Zoom meeting...")}
                                 fontWeight={"normal"}
                                 _hover={{

--- a/src/components/WelcomeToSDC.tsx
+++ b/src/components/WelcomeToSDC.tsx
@@ -64,7 +64,7 @@ export const WelcomeToSDC: React.FC<WelcomeToSDCProps> = ({ session }) => {
                                                         .LightBlue,
                                             }}
                                             width="50%"
-                                            borderRadius={100}
+                                            borderRadius="6px"
                                             fontWeight={"200"}
                                         >
                                             {t("home.registerNow")}
@@ -104,7 +104,7 @@ export const WelcomeToSDC: React.FC<WelcomeToSDCProps> = ({ session }) => {
                                                         .LightBlue,
                                             }}
                                             width="50%"
-                                            borderRadius={100}
+                                            borderRadius="6px"
                                             fontWeight={"200"}
                                         >
                                             {t("home.registerNow")}

--- a/src/components/parent-form/ParentCreatedPage.tsx
+++ b/src/components/parent-form/ParentCreatedPage.tsx
@@ -118,7 +118,7 @@ export const ParentCreatedPage: React.FC<ParentCreatedPageProps> = ({
                                     }}
                                     _active={{}}
                                     fontWeight={"200"}
-                                    borderRadius={100}
+                                    borderRadius="6px"
                                 >
                                     Browse Classes
                                 </Button>

--- a/src/components/volunteer-form/VolunteerCreatedPage.tsx
+++ b/src/components/volunteer-form/VolunteerCreatedPage.tsx
@@ -116,7 +116,7 @@ export const VolunteerCreatedPage: React.FC<VolunteerCreatedPageProps> = ({
                                     }}
                                     _active={{}}
                                     fontWeight={"200"}
-                                    borderRadius={100}
+                                    borderRadius="6px"
                                 >
                                     Browse Classes
                                 </Button>


### PR DESCRIPTION
### Notion ticket link

[Convert round buttons to square buttons as per Figma Design](https://www.notion.so/uwblueprintexecs/Convert-round-buttons-to-square-buttons-as-per-Figma-Design-200d2d78555c4666a7d6baa930ec17f2)

### Implementation description

- Change all borderRadius to be equal to 6px, as was mostly used throughout the codebase

### Steps to test

1. `ctrl + f` the borderRadius in the repo
2. Go to all the pages that show up to ensure that there are no  buttons that were missed

### What should reviewers focus on?

- The squareness of the buttons

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
