### PR TITLE
fix(api): absolute paths

### DIFF
--- a/pages/parent/signup.tsx
+++ b/pages/parent/signup.tsx
@@ -420,7 +420,7 @@ export default function ParticipantInfo({
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(userData),
         };
-        const response = await fetch("api/user", request);
+        const response = await fetch("/api/user", request);
         const updatedUserData = await response.json();
         return updatedUserData;
     }

--- a/pages/volunteer/signup.tsx
+++ b/pages/volunteer/signup.tsx
@@ -183,7 +183,7 @@ export default function VolunteerInfo({
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(userData),
         };
-        const response = await fetch("api/user", request);
+        const response = await fetch("/api/user", request);
         const updatedUserData = await response.json();
         return updatedUserData;
     }

--- a/utils/deleteClassRegistration.ts
+++ b/utils/deleteClassRegistration.ts
@@ -36,7 +36,7 @@ export async function deleteClassRegistration(
         body: JSON.stringify(registrationData),
     };
 
-    const response = await fetch("api/enroll/child", request);
+    const response = await fetch("/api/enroll/child", request);
     const deletedRegistration = await response.json();
 
     mutate("/api/enroll/child");

--- a/utils/deleteVolunteerRegistration.ts
+++ b/utils/deleteVolunteerRegistration.ts
@@ -22,7 +22,7 @@ export async function deleteVolunteerRegistration(
         body: JSON.stringify(registrationData),
     };
 
-    const response = await fetch("api/enroll/volunteer", request);
+    const response = await fetch("/api/enroll/volunteer", request);
     const deletedRegistration = await response.json();
 
     mutate("/api/enroll/volunteer");


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[API Calls Broken With Locale subpath](https://www.notion.so/uwblueprintexecs/API-Calls-Broken-With-Locale-subpath-453eda7d7b3e48e292f7c66031e6be85)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- For all api calls, we want them to be absolute, otherwise it may conflict with our new locale subpaths!

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. All affected api calls still work

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
