### PR TITLE
Add redirect parameter to document upload

### DIFF
--- a/pages/document-upload.tsx
+++ b/pages/document-upload.tsx
@@ -1,13 +1,20 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import { Button, Box, Center, Text, VStack, Spinner } from "@chakra-ui/react";
+import {
+    Button,
+    Box,
+    Center,
+    Text,
+    VStack,
+    Spinner,
+    Image,
+} from "@chakra-ui/react";
 import { GetServerSideProps } from "next"; // Get server side props
 import { getSession, GetSessionOptions } from "next-auth/client";
 import Wrapper from "@components/SDCWrapper";
 import DragAndDrop from "@components/DragAndDrop";
 import { BackButton } from "@components/BackButton";
 import { CloseButton } from "@components/CloseButton";
-import { ApprovedIcon } from "@components/icons";
 
 type DocumentUploadProps = {
     session: Record<string, unknown>;
@@ -16,7 +23,9 @@ export default function documentUpload({
     session,
 }: DocumentUploadProps): JSX.Element {
     const router = useRouter();
+
     let { type } = router.query;
+    const { redirect } = router.query;
     // sends file to other folder if type is not valid
     type = type && type.length > 0 ? type : "other";
 
@@ -132,12 +141,15 @@ export default function documentUpload({
     const uploadSuccessUI = (): JSX.Element => {
         return (
             <Wrapper session={session}>
-                <CloseButton />
+                <CloseButton href={`${redirect as string}`} />
                 <VStack>
                     <Center>
                         <Box width="400px" mb="40px">
                             <Center>
-                                <ApprovedIcon />
+                                <Image
+                                    src=""
+                                    alt="TODO checkmark image"
+                                ></Image>
                             </Center>
                             <Center>
                                 <Text fontWeight="700" fontSize="25px" m="20px">

--- a/pages/document-upload.tsx
+++ b/pages/document-upload.tsx
@@ -1,20 +1,13 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
-import {
-    Button,
-    Box,
-    Center,
-    Text,
-    VStack,
-    Spinner,
-    Image,
-} from "@chakra-ui/react";
+import { Button, Box, Center, Text, VStack, Spinner } from "@chakra-ui/react";
 import { GetServerSideProps } from "next"; // Get server side props
 import { getSession, GetSessionOptions } from "next-auth/client";
 import Wrapper from "@components/SDCWrapper";
 import DragAndDrop from "@components/DragAndDrop";
 import { BackButton } from "@components/BackButton";
 import { CloseButton } from "@components/CloseButton";
+import { ApprovedIcon } from "@components/icons";
 
 type DocumentUploadProps = {
     session: Record<string, unknown>;
@@ -23,7 +16,6 @@ export default function documentUpload({
     session,
 }: DocumentUploadProps): JSX.Element {
     const router = useRouter();
-
     let { type } = router.query;
     const { redirect } = router.query;
     // sends file to other folder if type is not valid
@@ -146,10 +138,7 @@ export default function documentUpload({
                     <Center>
                         <Box width="400px" mb="40px">
                             <Center>
-                                <Image
-                                    src=""
-                                    alt="TODO checkmark image"
-                                ></Image>
+                                <ApprovedIcon />
                             </Center>
                             <Center>
                                 <Text fontWeight="700" fontSize="25px" m="20px">


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

Add redirect parameter to document upload

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a redirect parameter accepted by the document upload page
- after upload, the upload success UI page has a close button, where clicking the close button will send the user to the redirect parameter link instead of going back
- to be used whenever the document upload page is required (eg. volunteer enrollment)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Pass parameters into document upload and click on the close button (X button) after uploading a file

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
