### PR TITLE
feat(s3-retrieve-file): add get s3 + cleanup

### DIFF
--- a/pages/api/file/retrieve/index.ts
+++ b/pages/api/file/retrieve/index.ts
@@ -1,0 +1,81 @@
+import { getSignedUrlForRetrieve } from "@aws/s3";
+import { ResponseUtil } from "@utils/responseUtil";
+import { getSession } from "next-auth/client"; // Session handling
+import { NextApiRequest, NextApiResponse } from "next";
+import { roles } from ".prisma/client";
+import { getUserFromEmail } from "@database/user";
+
+export default async function handle(
+    req: NextApiRequest,
+    res: NextApiResponse,
+): Promise<void> {
+    const session = await getSession({ req });
+    // If there is no session
+    if (!session) {
+        return ResponseUtil.returnUnauthorized(res, "Unauthorized");
+    }
+
+    // TODO make this more robost/better
+    const accepted_type_paths = [
+        "criminal-check",
+        "income-proof",
+        "curriculum-plans",
+    ];
+
+    // Attempt to retrieve file requested in user namespace if possible
+    let { file, path } = req.query;
+
+    if (path && !accepted_type_paths.includes(path as string)) {
+        return ResponseUtil.returnNotFound(res, "Type not accepted");
+    }
+
+    switch (req.method) {
+        case "GET": {
+            const user = await getUserFromEmail(session.user.email);
+
+            if (!user) {
+                return ResponseUtil.returnUnauthorized(res, "Unauthorized");
+            }
+            if (!path) {
+                if (user.role === roles.VOLUNTEER) {
+                    path = accepted_type_paths[0];
+                } else if (user.role === roles.PARENT) {
+                    path = accepted_type_paths[1];
+                } else {
+                    return ResponseUtil.returnBadRequest(
+                        res,
+                        "Path needs to be specified for this user",
+                    );
+                }
+            }
+            if (!file) {
+                // Try to get file name in
+                if (user.volunteer?.criminalRecordCheckLink) {
+                    file = user.volunteer.criminalRecordCheckLink;
+                } else if (user.parent?.proofOfIncomeLink) {
+                    file = user.parent.proofOfIncomeLink;
+                } else {
+                    return ResponseUtil.returnNotFound(res, "File not found");
+                }
+            }
+
+            const uploadFilePath = `${path}/${user.email}/${file}`;
+
+            const url = getSignedUrlForRetrieve(
+                process.env.S3_UPLOAD_BUCKET,
+                uploadFilePath,
+            );
+
+            ResponseUtil.returnOK(res, url);
+            break;
+        }
+        default: {
+            const allowedHeaders: string[] = ["GET"];
+            ResponseUtil.returnMethodNotAllowed(
+                res,
+                allowedHeaders,
+                `Method ${req.method} Not Allowed`,
+            );
+        }
+    }
+}

--- a/pages/document-upload.tsx
+++ b/pages/document-upload.tsx
@@ -34,10 +34,7 @@ export default function documentUpload({
             // TODO don't prefix file name, instead put random file name into database eventually
             // TODO randomize filename
             const res = await fetch(
-                `/api/upload/url?path=${type}&file=${
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    (session.user as any).email
-                }-${session.id}-${file.name}`,
+                `/api/file/upload?path=${type}&file=${file.name}`,
             );
             const data = await res.json();
             const { url, fields } = data.data;

--- a/pages/program-details/[pid].tsx
+++ b/pages/program-details/[pid].tsx
@@ -5,13 +5,13 @@ import { getSession } from "next-auth/client";
 import { ProgramInfo } from "@components/ProgramInfo";
 import useSWR from "swr";
 import CardInfoUtil from "utils/cardInfoUtil";
-import fetcherWithId from "@utils/fetcherWithId";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { locale } from "@prisma/client";
 import { Loading } from "@components/Loading";
 import Participants from "@utils/containers/Participants";
 import useMe from "@utils/useMe";
+import { fetcherWithId } from "@utils/fetcher";
 
 type ProgramDetailsProps = {
     session: Record<string, unknown>;

--- a/pages/volunteer/enrollment.tsx
+++ b/pages/volunteer/enrollment.tsx
@@ -6,7 +6,6 @@ import { ConfirmClassEnrollment } from "@components/volunteer-enroll/ConfirmClas
 import { UpdateCriminalCheckForm } from "@components/volunteer-enroll/UpdateCriminalCheck";
 import { useRouter } from "next/router";
 import useSWR from "swr";
-import fetcherWithId from "@utils/fetcherWithId";
 import useMe from "@utils/useMe";
 import { Box } from "@chakra-ui/layout";
 import { Loading } from "@components/Loading";
@@ -15,6 +14,7 @@ import { getSession } from "next-auth/client";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import CardInfoUtil from "@utils/cardInfoUtil";
 import { locale } from "@prisma/client";
+import { fetcherWithId } from "@utils/fetcher";
 
 type VolunteerEnrollmentProps = {
     session: Record<string, unknown>;

--- a/services/aws/s3.ts
+++ b/services/aws/s3.ts
@@ -100,4 +100,49 @@ const deleteFileFromS3 = (
     });
 };
 
-export { uploadFileToS3, getFileFromS3, deleteFileFromS3 };
+/**
+ * Get presigned post object for file upload to be used in client side
+ * @param  {string} bucketName
+ * @param  {string} fileKey
+ * @returns S3.PresignedPost object representing url and fields required to upload file
+ */
+const getPresignedPostForUpload = (
+    bucketName: string,
+    fileKey: string,
+): S3.PresignedPost => {
+    const fileSizeLimitBytes = 5000000; // up to ~5MB
+
+    return s3.createPresignedPost({
+        Bucket: bucketName,
+        Fields: {
+            key: fileKey,
+        },
+        Conditions: [["content-length-range", 0, fileSizeLimitBytes]],
+    });
+};
+/**
+ * Get signed url to retrieve file to be used on the client side
+ * @param  {string} bucketName
+ * @param  {string} fileKey
+ * @returns string the url to retrieve the requested file
+ */
+const getSignedUrlForRetrieve = (
+    bucketName: string,
+    fileKey: string,
+): string => {
+    const secIn5Min = 60 * 5;
+
+    return s3.getSignedUrl("getObject", {
+        Bucket: bucketName,
+        Key: fileKey,
+        Expires: secIn5Min,
+    });
+};
+
+export {
+    uploadFileToS3,
+    getFileFromS3,
+    deleteFileFromS3,
+    getPresignedPostForUpload,
+    getSignedUrlForRetrieve,
+};

--- a/services/database/user.ts
+++ b/services/database/user.ts
@@ -7,7 +7,8 @@ import { User, roles } from "@prisma/client";
  * getUser takes the id parameter and returns the user associated with the userId
  * @param {string} id - userId
  */
-async function getUser(id: string): Promise<User> {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function getUser(id: string) {
     const user = await prisma.user.findUnique({
         where: {
             id: parseInt(id),
@@ -30,7 +31,8 @@ async function getUser(id: string): Promise<User> {
  * getUser takes the email parameter and returns a minimal user associated with the email
  * @param {string} email
  */
-async function getUserFromEmail(email: string): Promise<User> {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function getUserFromEmail(email: string) {
     const user = await prisma.user.findUnique({
         where: {
             email: email,
@@ -52,7 +54,8 @@ async function getUserFromEmail(email: string): Promise<User> {
 /**
  * getUsers returns all the users
  */
-async function getUsers(): Promise<User[]> {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function getUsers() {
     const users = await prisma.user.findMany({
         include: {
             teacher: true,
@@ -73,7 +76,8 @@ async function getUsers(): Promise<User[]> {
  * @param userInput - data for the updated user
  * @returns prisma User with updated information
  */
-async function updateUser(userInput: UserInput): Promise<User> {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function updateUser(userInput: UserInput) {
     /*
     Flow:
     - get role and role data from UserInput
@@ -311,10 +315,13 @@ async function updateUser(userInput: UserInput): Promise<User> {
     return updatedUser;
 }
 
-async function updateVolunteerCriminalCheckLink(
-    email: string,
-    link: string,
-): Promise<User> {
+/**
+ * update volunteer's criminal check link in db to keep track of latest upload
+ * @param  {string} email email of volunteer
+ * @param  {string} link criminal check link name
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function updateVolunteerCriminalCheckLink(email: string, link: string) {
     const user = prisma.user.update({
         data: {
             volunteer: {
@@ -332,10 +339,13 @@ async function updateVolunteerCriminalCheckLink(
     return user;
 }
 
-async function updateParentProofOfIncomeLink(
-    email: string,
-    link: string,
-): Promise<User> {
+/**
+ * update parent's proof of income link in db to keep track of latest upload
+ * @param  {string} email email of parent
+ * @param  {string} link proof of income link name
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function updateParentProofOfIncomeLink(email: string, link: string) {
     const user = prisma.user.update({
         data: {
             parent: {

--- a/utils/fetcher.ts
+++ b/utils/fetcher.ts
@@ -3,6 +3,39 @@
  * @param url route to call fetch
  * @returns the promise corresponding to the response of the route
  */
-export default function fetcher(url: string): Promise<any> {
+export function fetcher(url: string): Promise<any> {
     return fetch(url).then((r) => r.json());
+}
+
+/**
+ * Generic fetcher with id
+ * @param url route to call fetch
+ * @returns the promise corresponding to the response of the route
+ */
+export function fetcherWithId(url: string, id: string): Promise<any> {
+    return fetcher(`${url}?id=${id}`);
+}
+/**
+ * Generic fetcher with file and path for S3 APIs
+ * @param  {string} url
+ * @param  {string} path
+ * @param  {string} file
+ * @returns the promise corresponding to the response of the route
+ */
+export function fetcherWithPathFile(
+    url: string,
+    path?: string,
+    file?: string,
+): Promise<any> {
+    let endpoint = `${url}`;
+
+    if (path && file) {
+        endpoint += `?path=${path}&file=${file}`;
+    } else if (path) {
+        endpoint += `?path=${path}`;
+    } else if (file) {
+        endpoint += `?file=${file}`;
+    }
+
+    return fetcher(endpoint);
 }

--- a/utils/fetcherWithId.ts
+++ b/utils/fetcherWithId.ts
@@ -1,8 +1,0 @@
-/**
- * Generic fetcher with id
- * @param url route to call fetch
- * @returns the promise corresponding to the response of the route
- */
-export default function fetcherWithId(url: string, id: string): Promise<any> {
-    return fetch(`${url}?id=${id}`).then((r) => r.json());
-}

--- a/utils/useFileRetrieve.ts
+++ b/utils/useFileRetrieve.ts
@@ -1,0 +1,28 @@
+import useSWR from "swr";
+import { fetcherWithPathFile } from "./fetcher";
+
+export type UseFileRetrieveResponse = {
+    url: string;
+    isLoading: boolean;
+    error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
+};
+
+/**
+ * File retrieve hook to get url to download file in bucket
+ */
+export default function useFileRetrieve(
+    path?: string,
+    file?: string,
+): UseFileRetrieveResponse {
+    const { data, error, mutate } = useSWR(
+        ["/api/file/retrieve", path, file],
+        fetcherWithPathFile,
+    );
+    return {
+        url: data ? data.data : null,
+        isLoading: !error && !data,
+        error,
+        mutate,
+    };
+}

--- a/utils/useFileUpload.ts
+++ b/utils/useFileUpload.ts
@@ -1,0 +1,29 @@
+import useSWR from "swr";
+import { S3 } from "services/aws/index";
+import { fetcherWithPathFile } from "./fetcher";
+
+export type UseFileUploadResponse = {
+    post: S3.PresignedPost;
+    isLoading: boolean;
+    error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
+};
+
+/**
+ * File upload presigned url hook to upload file
+ */
+export default function useFileUpload(
+    path?: string,
+    file?: string,
+): UseFileUploadResponse {
+    const { data, error, mutate } = useSWR(
+        ["/api/file/retrieve", path, file],
+        fetcherWithPathFile,
+    );
+    return {
+        post: data ? data.data : null,
+        isLoading: !error && !data,
+        error,
+        mutate,
+    };
+}

--- a/utils/useGetZoomLink.ts
+++ b/utils/useGetZoomLink.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
 export type UseGetZoomLinkResponse = {
     link: string;

--- a/utils/useMe.ts
+++ b/utils/useMe.ts
@@ -7,7 +7,7 @@ import {
     Volunteer,
 } from "@prisma/client";
 import useSWR from "swr";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
 export type UseMeResponse = {
     me: User & {

--- a/utils/useParentRegistration.ts
+++ b/utils/useParentRegistration.ts
@@ -2,12 +2,13 @@ import { EnrollmentCardInfo } from "@models/Enroll";
 import { locale } from "@prisma/client";
 import useSWR from "swr";
 import CardInfoUtil from "./cardInfoUtil";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
 export type UseParentRegistrationsResponse = {
     enrollments: EnrollmentCardInfo[];
     isLoading: boolean;
     error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
 };
 
 /**
@@ -17,13 +18,14 @@ export type UseParentRegistrationsResponse = {
 export default function useParentRegistrations(
     language: locale,
 ): UseParentRegistrationsResponse {
-    const { data, error } = useSWR("/api/enroll/child", fetcher);
+    const { data, error, mutate } = useSWR("/api/enroll/child", fetcher);
     const result = data
         ? CardInfoUtil.getEnrollmentCardInfos(data.data, language)
         : [];
     return {
         enrollments: result,
         isLoading: !error && !data,
-        error: error,
+        error,
+        mutate,
     };
 }

--- a/utils/usePrograms.ts
+++ b/utils/usePrograms.ts
@@ -2,12 +2,13 @@ import { ProgramCardInfo } from "@models/Program";
 import { locale } from "@prisma/client";
 import useSWR from "swr";
 import CardInfoUtil from "./cardInfoUtil";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
 export type UseProgramsResponse = {
     programs: ProgramCardInfo[];
     isLoading: boolean;
     error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
 };
 
 /**
@@ -16,13 +17,14 @@ export type UseProgramsResponse = {
  * @returns UseProgramsResponse
  */
 export default function usePrograms(language: locale): UseProgramsResponse {
-    const { data, error } = useSWR("/api/program", fetcher);
+    const { data, error, mutate } = useSWR("/api/program", fetcher);
     const result = data
         ? CardInfoUtil.getProgramCardInfos(data.data, language)
         : [];
     return {
         programs: result,
         isLoading: !error && !data,
-        error: error,
+        error,
+        mutate,
     };
 }

--- a/utils/useUser.ts
+++ b/utils/useUser.ts
@@ -1,11 +1,34 @@
+import {
+    Parent,
+    ProgramAdmin,
+    Student,
+    Teacher,
+    User,
+    Volunteer,
+} from "@prisma/client";
 import useSWR from "swr";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
-export default function useUser(id: string): any {
-    const { data, error } = useSWR(`/api/user/${id}`, fetcher);
+export type UseUserResponse = {
+    user: User & {
+        parent: Parent & {
+            students: Student[];
+        };
+        teacher: Teacher;
+        programAdmin: ProgramAdmin;
+        volunteer: Volunteer;
+    };
+    isLoading: boolean;
+    error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
+};
+
+export default function useUser(id: string): UseUserResponse {
+    const { data, error, mutate } = useSWR(`/api/user/${id}`, fetcher);
     return {
         user: data ? data.data : null,
         isLoading: !error && !data,
-        error: error,
+        error,
+        mutate,
     };
 }

--- a/utils/useVolunteerRegistration.ts
+++ b/utils/useVolunteerRegistration.ts
@@ -2,12 +2,13 @@ import { VolunteeringCardInfo } from "@models/Enroll";
 import { locale } from "@prisma/client";
 import useSWR from "swr";
 import CardInfoUtil from "./cardInfoUtil";
-import fetcher from "./fetcher";
+import { fetcher } from "./fetcher";
 
 export type UseVolunteerRegistrationsResponse = {
     volunteering: VolunteeringCardInfo[];
     isLoading: boolean;
     error: any;
+    mutate: (data?: any, shouldRevalidate?: boolean) => Promise<any>;
 };
 
 /**
@@ -17,13 +18,14 @@ export type UseVolunteerRegistrationsResponse = {
 export default function useVolunteerRegistrations(
     language: locale,
 ): UseVolunteerRegistrationsResponse {
-    const { data, error } = useSWR("/api/enroll/volunteer", fetcher);
+    const { data, error, mutate } = useSWR("/api/enroll/volunteer", fetcher);
     const result = data
         ? CardInfoUtil.getVolunteeringCardInfos(data.data, language)
         : [];
     return {
         volunteering: result,
         isLoading: !error && !data,
-        error: error,
+        error,
+        mutate,
     };
 }


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

Sample link workflow
[Rework file upload names + retrieve file](https://www.notion.so/uwblueprintexecs/Rework-file-upload-names-retrieve-file-442043c01a804a0ca0f6a60a913e8ae8)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

https://user-images.githubusercontent.com/44826218/138379709-324c15ab-3890-40f0-9817-0e6b5894b890.mp4

### Implementation description

- Use signed url to get items from bucket
- Add SWR hook for retrieve file
- Cleanup SWR hooks
- Add appropriate utils
- Reworked file upload paths to be `/<type>/<user-email>/filename.type` - eg: `criminal-check/rickson@uwbp.com/poi.pdf`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Create a stub open file button
2. The right file should be downloaded, depending on whether or not you are a volunteer, parent

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Code style
- Any missing small oversights

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
