### PR TITLE
Update eslint and prettier commands

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,11 +12,7 @@
     ],
     "rules": {
         "prettier/prettier": [
-            //Automatically set the end of line character for those on unix
-            "error",
-            {
-                "endOfLine": "auto"
-            }
+            "error"
         ]
     },
     "env": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,19 @@ jobs:
             - name: Install dependencies
               run: yarn
 
-            - name: Linting ALl Prettier
+            - name: Linting All Prettier on push
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:prettier
 
-            - name: Linting All ESlint
+            - name: Linting All ESlint on push
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:eslint
             
-            - name: Linting Modified Files Prettier
+            - name: Linting Modified Files Prettier on pull request
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:prettier-modified-files
 
-            - name: Linting Modified Files ESlint
+            - name: Linting Modified Files ESlint on pull request
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:eslint-modified-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,19 @@ jobs:
             - name: Install dependencies
               run: yarn
 
-            - name: Linting All Prettier on push
+            - name: Linting all Prettier on push
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:prettier
 
-            - name: Linting All ESlint on push
+            - name: Linting all ESlint on push
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:eslint
             
-            - name: Linting Modified Files Prettier on pull request
+            - name: Linting modified files Prettier on pull request
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:prettier-modified-files
 
-            - name: Linting Modified Files ESlint on pull request
+            - name: Linting modified files ESlint on pull request
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:eslint-modified-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,20 @@ jobs:
               run: yarn
 
             - name: Linting Prettier
+              if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:prettier
 
             - name: Linting ESlint
+              if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:eslint
+            
+             - name: Linting Prettier
+              if: ${{ github.event_name == 'pull_request' }}
+              run: yarn lint:prettier-modified-files
+
+            - name: Linting ESlint
+              if: ${{ github.event_name == 'pull_request' }}
+              run: yarn lint:eslint-modified-files
 
             - name: Build
               run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,19 @@ jobs:
             - name: Install dependencies
               run: yarn
 
-            - name: Linting Prettier
+            - name: Linting ALl Prettier
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:prettier
 
-            - name: Linting ESlint
+            - name: Linting All ESlint
               if: ${{ github.event_name != 'pull_request' }}
               run: yarn lint:eslint
             
-             - name: Linting Prettier
+            - name: Linting Modified Files Prettier
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:prettier-modified-files
 
-            - name: Linting ESlint
+            - name: Linting Modified Files ESlint
               if: ${{ github.event_name == 'pull_request' }}
               run: yarn lint:eslint-modified-files
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,4 @@
     "singleQuote": false,
     "printWidth": 80,
     "tabWidth": 4,
-    "eol": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "start": "next start --port ${PORT-3000}",
         "svgr": "npx @svgr/cli -d src/components/icons --ignore-existing --icon --typescript public/icons",
         "lint": "yarn lint:prettier && yarn lint:eslint",
-        "lint:prettier": "prettier --check '*.{js,jsx,ts,tsx}'",
-        "lint:eslint": "eslint '*.{js,jsx,ts,tsx}' --cache --format stylish",
+        "lint:prettier": "prettier --check '**/*.{js,jsx,ts,tsx}'",
+        "lint:eslint": "eslint '**/*.{js,jsx,ts,tsx}' --cache --format stylish",
         "fix": "yarn fix:eslint && yarn fix:prettier",
-        "fix:prettier": "prettier --write '*.{js,jsx,ts,tsx}'",
-        "fix:eslint": "eslint '*.{js,jsx,ts,tsx}' --format stylish --fix"
+        "fix:prettier": "prettier --write '**/*.{js,jsx,ts,tsx}'",
+        "fix:eslint": "eslint '**/*.{js,jsx,ts,tsx}' --format stylish --fix"
     },
     "prisma": {
         "seed": "ts-node -O {\"module\":\"CommonJS\"} prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
         "start": "next start --port ${PORT-3000}",
         "svgr": "npx @svgr/cli -d src/components/icons --ignore-existing --icon --typescript public/icons",
         "lint": "yarn lint:prettier && yarn lint:eslint",
+        "lint-modified-files":"yarn lint:prettier-modified-files && yarn lint:eslint-modified-files",
         "lint:prettier": "prettier --check '**/*.{js,jsx,ts,tsx}'",
+        "lint:prettier-modified-files": "prettier --check --no-error-on-unmatched-pattern  $(git diff --name-only --diff-filter=d HEAD | grep -E '(.js|.jsx|.ts|.tsx)$' | xargs)",
         "lint:eslint": "eslint '**/*.{js,jsx,ts,tsx}' --cache --format stylish",
+        "lint:eslint-modified-files": "eslint $(git diff --name-only --diff-filter=d HEAD | grep -E '(.js|.jsx|.ts|.tsx)$' | xargs) --cache --format stylish",
         "fix": "yarn fix:eslint && yarn fix:prettier",
         "fix:prettier": "prettier --write '**/*.{js,jsx,ts,tsx}'",
         "fix:eslint": "eslint '**/*.{js,jsx,ts,tsx}' --format stylish --fix"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Setup-PR-decoration-with-github-actions-a715af80d0fd4dd3a17015bbc14fecb1)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Changed eslint and prettier file paths in `package.json` from eslint '*.{js,jsx,ts,tsx}'  to `**/*.{js,jsx,ts,tsx}'
    - makes eslint actually lint over all files in repo not just top directory
- Added new scripts to lint only modified files (lint:prettier-modified-files, lint:eslint-modified-files, lint-modified-files)
    - NOTE, prettier will error if there are no matching modified files for some reason FWI
- Updated workflow action in order to detect github event (on pullrequest vs on push) in order to run either the modified files lint or not

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Run `yarn lint`
2. Run `yarn lint-modified-files`

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
