### PR TITLE
[Bug Fixes] Trim input to text fields & fix parent registration message

### DIFF
--- a/src/components/formFields/TextField.tsx
+++ b/src/components/formFields/TextField.tsx
@@ -27,6 +27,9 @@ export const TextField: React.FC<Props> = ({
     edit = true,
 }): JSX.Element => {
     const [interactedWith, setInteractedWith] = useState(false);
+    const formatInput = () => {
+        setValue(value.trim());
+    };
 
     return (
         <FormControl
@@ -46,6 +49,7 @@ export const TextField: React.FC<Props> = ({
                         setInteractedWith(true);
                     }}
                     value={value}
+                    onBlur={formatInput}
                 ></Textarea>
             ) : (
                 <Input
@@ -54,6 +58,7 @@ export const TextField: React.FC<Props> = ({
                         setValue(e.target.value);
                         setInteractedWith(true);
                     }}
+                    onBlur={formatInput}
                     value={value}
                 />
             )}

--- a/src/components/parent-form/ParentCreatedPage.tsx
+++ b/src/components/parent-form/ParentCreatedPage.tsx
@@ -112,7 +112,7 @@ export const ParentCreatedPage: React.FC<ParentCreatedPageProps> = ({
                         </Text>
                         <Text maxW={512} textAlign="center">
                             {successful === "success"
-                                ? "Your account has been successfully created. Click the button below to start browsing classes to volunteer for!"
+                                ? "Your account has been successfully created. Click the button below to start browsing classes to register for!"
                                 : "There was an error creating your account. Please contact us"}
                         </Text>
                         <Link href="/">


### PR DESCRIPTION
### Bugs
1. Input fields to the registration form allowed empty spaces. Therefore you could have submitted spaces as your name, etc. 
2. The successful registration message for parents said "Your account has been successfully created. Click the button below to start browsing classes to **volunteer** for!"

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description
1. Trim the input once the user clicks out of the input (blur) and set it as the input value. This gets rid of any leading or trailing spaces.


https://user-images.githubusercontent.com/43686735/140266715-147a1424-239b-4802-8bb1-dd48c726865c.mp4



2. Update the success message to say "Your account has been successfully created. Click the button below to start browsing classes to **register** for!"


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

Bug 1:
1. sign up for a new account
2. When putting information into a text field, try entering only spaces. Once you click out, the field should be invalid.
3. Enter spaces, some text, and trailing spaces. When you click out, the leading and trailing spaces should be removed.

Bug 2:
1. Go through registration flow as a parent.
2. Text upon completing the flow should be updated to say "register" instead of "volunteer".

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
