### PR TITLE
Bug fix: change descriptions for some success messages

### DIFF
--- a/pages/parent/participant.tsx
+++ b/pages/parent/participant.tsx
@@ -420,6 +420,7 @@ export default function ParticipantInfo({
             setPageNum={setPageNum}
             totalPages={totalPages}
             formPages={formPages}
+            name={`${participantFirstName} ${participantLastName}`}
         />
     );
 }

--- a/src/components/parent-form/ParticipantCreatedPage.tsx
+++ b/src/components/parent-form/ParticipantCreatedPage.tsx
@@ -115,11 +115,11 @@ export const ParticipantCreatedPage: React.FC<ParticipantCreatedPageProps> = ({
                         </Text>
                         <Text maxW={400} textAlign="center" pt={3} pb={9}>
                             {successful === "success" ? (
-                                <div>
+                                <>
                                     <strong>{name}</strong> has been
                                     successfully added as a participant in your
                                     account!
-                                </div>
+                                </>
                             ) : (
                                 "There was an error adding the participant. Please contact us"
                             )}

--- a/src/components/parent-form/ParticipantCreatedPage.tsx
+++ b/src/components/parent-form/ParticipantCreatedPage.tsx
@@ -113,7 +113,7 @@ export const ParticipantCreatedPage: React.FC<ParticipantCreatedPageProps> = ({
                         </Text>
                         <Text maxW={400} textAlign="center" pt={3} pb={9}>
                             {successful === "success"
-                                ? "Participant has been successfully added as a participant in your account"
+                                ? "The participant has been successfully added to your account"
                                 : "There was an error adding the participant. Please contact us"}
                         </Text>
                         <Button

--- a/src/components/parent-form/ParticipantCreatedPage.tsx
+++ b/src/components/parent-form/ParticipantCreatedPage.tsx
@@ -26,6 +26,7 @@ type ParticipantCreatedPageProps = {
     setPageNum: any;
     totalPages: number;
     formPages: JSX.Element[];
+    name: string;
 };
 
 export const ParticipantCreatedPage: React.FC<ParticipantCreatedPageProps> = ({
@@ -35,6 +36,7 @@ export const ParticipantCreatedPage: React.FC<ParticipantCreatedPageProps> = ({
     totalPages,
     formPages,
     successful,
+    name,
 }): JSX.Element => {
     const router = useRouter();
 
@@ -112,9 +114,15 @@ export const ParticipantCreatedPage: React.FC<ParticipantCreatedPageProps> = ({
                                 : "Error: Participant not added successfully"}
                         </Text>
                         <Text maxW={400} textAlign="center" pt={3} pb={9}>
-                            {successful === "success"
-                                ? "The participant has been successfully added to your account"
-                                : "There was an error adding the participant. Please contact us"}
+                            {successful === "success" ? (
+                                <div>
+                                    <strong>{name}</strong> has been
+                                    successfully added as a participant in your
+                                    account!
+                                </div>
+                            ) : (
+                                "There was an error adding the participant. Please contact us"
+                            )}
                         </Text>
                         <Button
                             bg={"transparent"}

--- a/src/components/registration-form/ParentEnrolledConfirmationPage.tsx
+++ b/src/components/registration-form/ParentEnrolledConfirmationPage.tsx
@@ -77,8 +77,8 @@ export const ParentEnrolledConfirmationPage: React.FC<ParentEnrolledConfirmation
                         {t("form.registered")}
                     </Text>
                     <Text maxW={512} textAlign="center" py={3}>
-                        We look forward to see you at our program. Look out for
-                        an email from us shortly with more information!
+                        We look forward to seeing you at our program. Look out
+                        for an email from us shortly with more information!
                     </Text>
                     <Link href="/class">
                         <Button


### PR DESCRIPTION
Adding a participant successfully:
Updated to include participant name.

Successfully registering for a class:
This was grammatically incorrect.


### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
