### PR TITLE
feature - send waitlist emails when parent unregisters from class

### DIFF
--- a/pages/api/enroll/child.ts
+++ b/pages/api/enroll/child.ts
@@ -15,6 +15,7 @@ import { getClass } from "@database/class";
 import { getWaitlistRecordsByClassId } from "@database/waitlist";
 import send from "services/nodemailer/mail";
 import { openSpotWaitlistTemplate } from "@utils/mail/templateWaitlist";
+import { IoRecordingOutline } from "react-icons/io5";
 
 /**
  * handle controls the request made to the enroll/child resource.
@@ -205,7 +206,7 @@ export default async function handle(
                         const emailSubject = `Spot Available for Waitlisted Class: ${waitlistClass.name}`;
                         return send(
                             process.env.EMAIL_FROM,
-                            (record as any).parent.user.email,
+                            record.parent.user.email,
                             emailSubject,
                             openSpotWaitlistTemplate(
                                 req.body.classId,

--- a/pages/api/enroll/child.ts
+++ b/pages/api/enroll/child.ts
@@ -177,9 +177,11 @@ export default async function handle(
                 return;
             }
 
+            // check if there exists waitlist records for this class
             const waitlistRecords = await getWaitlistRecordsByClassId(
                 parentRegistrationInput.classId,
             );
+            // if there are, get class information & send email to all on waitlist
             if (waitlistRecords.length > 0) {
                 const waitlistClass = await getClass(
                     parentRegistrationInput.classId,
@@ -214,7 +216,6 @@ export default async function handle(
                         ),
                     );
                 });
-                // // send all the reminder emails to the respective users
                 await Promise.all(mailerPromises);
             }
 

--- a/services/database/enroll.ts
+++ b/services/database/enroll.ts
@@ -100,13 +100,25 @@ async function createParentRegistration(
  */
 async function deleteParentRegistration(
     parentRegistrationData: ParentRegistrationInput,
-): Promise<ParentReg> {
+) {
     const parentRegistration = await prisma.parentReg.delete({
         where: {
             parentId_studentId_classId: {
                 parentId: parentRegistrationData.parentId,
                 studentId: parentRegistrationData.studentId,
                 classId: parentRegistrationData.classId,
+            },
+        },
+        include: {
+            class: {
+                include: {
+                    _count: {
+                        select: {
+                            parentRegs: true,
+                            volunteerRegs: true,
+                        },
+                    },
+                },
             },
         },
     });

--- a/services/database/waitlist.ts
+++ b/services/database/waitlist.ts
@@ -30,6 +30,13 @@ async function getWaitlistRecordsByClassId(
         where: {
             classId: classId,
         },
+        include: {
+            parent: {
+                include: {
+                    user: true,
+                },
+            },
+        },
         orderBy: {
             createdAt: "asc", // ascending order as the oldest createdAt date is the highest priority.
         },

--- a/services/database/waitlist.ts
+++ b/services/database/waitlist.ts
@@ -23,9 +23,8 @@ async function getWaitlistRecord(input: WaitlistInput): Promise<Waitlist> {
  * @param classId
  * @returns Promise<Waitlist[]> - Promise with list of waitlist records associated with the class
  */
-async function getWaitlistRecordsByClassId(
-    classId: number,
-): Promise<Waitlist[]> {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+async function getWaitlistRecordsByClassId(classId: number) {
     const waitlistRecords = await prisma.waitlist.findMany({
         where: {
             classId: classId,

--- a/utils/mail/templateWaitlist.ts
+++ b/utils/mail/templateWaitlist.ts
@@ -84,6 +84,10 @@ export const openSpotWaitlistTemplate = (
                         </span>
                     </div>
                 </div>
+                <p style="font-style: normal;
+                    font-weight: normal;
+                    font-size: 16px;
+                    line-height: 24px;">Please note that registration is first come, first serve.</p>
                 <br></br>
                 <p>Use this link to register for the class:</p>
                 <a href="${

--- a/utils/mail/templateWaitlist.ts
+++ b/utils/mail/templateWaitlist.ts
@@ -1,0 +1,105 @@
+import { locale, weekday } from "@prisma/client";
+import convertToShortDateRange from "@utils/convertToShortDateRange";
+import convertToShortTimeRange from "@utils/convertToShortTimeRange";
+import { weekdayToString } from "@utils/enum/weekday";
+
+/**
+ * Return html representing the waitlist notification template
+ * @param  {number} classId class id
+ * @param  {string} imageLink image link of class
+ * @param  {string} name name of class
+ * @param  {weekday} classWeekday repeated weekday of class
+ * @param  {Date} startDate date which class starts
+ * @param  {Date} endDate date which class ends
+ * @param  {number} startTimeMinutes starting time in minutes
+ * @param  {number} durationMinutes duration of session
+ * @return {string} html template
+ */
+
+export const openSpotWaitlistTemplate = (
+    classId: number,
+    imageLink: string,
+    name: string,
+    classWeekday: weekday,
+    startDate: Date,
+    endDate: Date,
+    startTimeMinutes: number,
+    durationMinutes: number,
+    language: locale = locale.en,
+): string => {
+    const { start, end } = convertToShortDateRange(
+        startDate,
+        endDate,
+        language,
+    );
+
+    return `
+            <head>
+                <link
+                    href="https://fonts.googleapis.com/css?family=Poppins"
+                    rel="stylesheet"
+                    />
+                <style>
+                    body {
+                    font-family: "Poppins";
+                    }
+                </style>
+            </head>
+            <body style="background-color: #fff; padding: 30px; position: absolute">
+                <p style="font-size: 30px"><img src=https://images.squarespace-cdn.com/content/5e83092341f99d6d384777ef/1592547010897-WF00319AKLJCVGJZC3ZK/sdc+logo+with+name+alt.png?content-type=image%2Fpng
+                    style="width: 250px; padding-bottom: 10px; color: #0c53a0" alt="SDC Logo"/></p>
+                <span style="font-style: normal;
+                    font-weight: bold;
+                    font-size: 24px;
+                    line-height: 36px;">A spot is available for ${name}!</span>
+                <p style="font-style: normal;
+                    font-weight: normal;
+                    font-size: 16px;
+                    line-height: 24px;">This is an automatic notification for waitlisted users of the following class:</p>
+                <div style="display: flex; flex-direction: row">
+                    <div
+                        style="
+                            width: 100px;
+                            height: 100px;
+                            background: url('${imageLink}');
+                            display: flex;
+                            background-size: cover;
+                        "
+                    ></div>
+                    <div style="padding-left: 10px">
+                        <span style="width: 375px; font-weight: Bold; font-size: 16px"
+                            >${name}</span
+                        ><br /><span
+                            style="width: 30px; color: rgba(115, 115, 115, 1); font-size: 14px"
+                            >${weekdayToString(
+                                classWeekday,
+                                language,
+                            )} ${convertToShortTimeRange(
+        startTimeMinutes,
+        durationMinutes,
+    )}</span
+                        ><br /><span
+                            style="width: 30px; color: rgba(115, 115, 115, 1); font-size: 14px"
+                        >${start} to ${end} 
+                        </span>
+                    </div>
+                </div>
+                <br></br>
+                <p>Use this link to register for the class:</p>
+                <a href="${
+                    process.env.NEXTAUTH_URL
+                }/program-details/${classId}">${
+        process.env.NEXTAUTH_URL
+    }/program-details/${classId}</a>
+                <br></br>
+                <br></br>
+                <p>Use this link to remove yourself from the class waitlist:</p>
+                <a href="${process.env.NEXTAUTH_URL}/class">${
+        process.env.NEXTAUTH_URL
+    }/class</a>
+                <br></br>
+                <br></br>
+                <p>Regards, Social Diversity for Children</p>
+            </body>
+            `;
+};


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Notion Ticket](https://www.notion.so/uwblueprintexecs/Send-email-after-class-registration-1e0c469cf3af466d812b9a84c2e161b3)
[Loom Demo Video](https://www.loom.com/share/b52c42d3accc483e91feaf01a55888f3)

<img width="1167" alt="Screen Shot 2021-11-14 at 7 29 16 PM" src="https://user-images.githubusercontent.com/45214377/141705477-4d8b5b71-7f16-469a-9892-e50b75ded73e.png">

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- in the DELETE request of `api/enroll/child` for a particular class, we:
1. get all waitlist records with same class ID
2. if there are records, we get the class info & for each class, we push an email to `mailerPromises`
3. then, send all waitlist emails 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

Test cases/things to consider:
- check if email will be sent to all (2+) waitlisted records for a specific class
-- I tested with 2 emails for one class waitlist, both emails received the waitlist email on unenrollment

- currently, a parent IS able to both be enrolled in a class & on the waitlist for the class (ie they may be waiting for another child)
- if multiple unenrollments occur within a time range, parents on waitlist would get multiple of the same email -> not sure if we want to do anything about this?

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- email template, wording, etc.

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
