### PR TITLE
chore(admin): add missing navbar headers to pages

### DIFF
--- a/pages/admin/add.tsx
+++ b/pages/admin/add.tsx
@@ -1,3 +1,4 @@
+import { roles } from ".prisma/client";
 import {
     Box,
     BoxProps,
@@ -14,6 +15,7 @@ import {
     Text,
     useToast,
 } from "@chakra-ui/react";
+import { AdminHeader } from "@components/admin/AdminHeader";
 import Wrapper from "@components/AdminWrapper";
 import { TextField } from "@components/formFields/TextField";
 import colourTheme from "@styles/colours";
@@ -24,6 +26,7 @@ import { GetServerSideProps } from "next"; // Get server side props
 import { Session } from "next-auth";
 import { getSession, signIn } from "next-auth/client";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useRouter } from "next/router";
 import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { MdCheckCircle } from "react-icons/md";
 import isEmail from "validator/lib/isEmail";
@@ -45,6 +48,7 @@ export default function AddInternalUser(props: AddInternalUserProps): JSX.Elemen
     const [adminEmail, setAdminEmail] = useState("");
     const [adminValid, setAdminValid] = useState(false);
     const toast = useToast();
+    const router = useRouter();
 
     useEffect(() => {
         if (teacherFirstName && teacherLastName && isEmail(teacherEmail)) {
@@ -116,7 +120,8 @@ export default function AddInternalUser(props: AddInternalUserProps): JSX.Elemen
 
     return (
         <Wrapper session={props.session}>
-            <Tabs mx={8} mt={8}>
+            <AdminHeader>Invite SDC Members</AdminHeader>
+            <Tabs mx={8} defaultIndex={router.query.role == roles.TEACHER.toLowerCase() ? 1 : 0}>
                 <TabList>
                     <Tab>Admin</Tab>
                     <Tab>Teacher</Tab>

--- a/pages/admin/archive/index.tsx
+++ b/pages/admin/archive/index.tsx
@@ -90,7 +90,7 @@ export const ArchiveBrowsePrograms: React.FC<ArchiveBrowseProgramsProps> = (prop
 
     return (
         <Wrapper session={props.session}>
-            <AdminHeader>Archive</AdminHeader>
+            <AdminHeader>Archived</AdminHeader>
 
             <Tabs mx={6}>
                 <TabList>

--- a/pages/admin/archive/program/[pid].tsx
+++ b/pages/admin/archive/program/[pid].tsx
@@ -78,14 +78,14 @@ export default function ArchivedProgramClassView({
 
     return (
         <Wrapper session={session}>
-            <AdminHeader>Archive</AdminHeader>
+            <AdminHeader>Archived</AdminHeader>
             <VStack mx={8} spacing={6} alignItems="flex-start">
                 <Breadcrumb separator={">"}>
                     <BreadcrumbItem>
                         <BreadcrumbLink href="/admin/archive">Browse Archived</BreadcrumbLink>
                     </BreadcrumbItem>
 
-                    <BreadcrumbItem>
+                    <BreadcrumbItem isCurrentPage>
                         <BreadcrumbLink href="#" fontWeight="bold">
                             {program.name}
                         </BreadcrumbLink>

--- a/pages/admin/class/[id].tsx
+++ b/pages/admin/class/[id].tsx
@@ -26,10 +26,16 @@ import { AdminError } from "@components/AdminError";
 import { AdminLoading } from "@components/AdminLoading";
 import { Session } from "next-auth";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { AdminHeader } from "@components/admin/AdminHeader";
 
 type ClassViewProps = {
     session: Session;
 };
+
+const headerLinks = [
+    { name: "Add Program", url: "/admin/program/create" },
+    { name: "Add Class", url: "/admin/class/create" },
+];
 
 /**
  * Admin class view page that displays the information about the class given a class id
@@ -63,7 +69,8 @@ export default function ClassView({ session }: ClassViewProps): JSX.Element {
 
     return (
         <Wrapper session={session}>
-            <VStack mx={8} spacing={8} mt={10} alignItems="flex-start">
+            <AdminHeader headerLinks={headerLinks}>Programs</AdminHeader>
+            <VStack mx={8} spacing={8} alignItems="flex-start">
                 <Breadcrumb separator={">"}>
                     <BreadcrumbItem>
                         <BreadcrumbLink href="/admin/program">Browse Programs</BreadcrumbLink>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -2,6 +2,7 @@ import { ArrowForwardIcon } from "@chakra-ui/icons";
 import { Box, Heading, HStack, Link as ChakraLink, Text, VStack } from "@chakra-ui/layout";
 import { Flex, List, ListItem, Spacer } from "@chakra-ui/react";
 import { AdminEmptyState } from "@components/admin/AdminEmptyState";
+import { AdminHeader } from "@components/admin/AdminHeader";
 import { AdminOptionButton } from "@components/admin/AdminOptionButton";
 import { AdminStatBox } from "@components/admin/AdminStatBox";
 import { LiveClassCard } from "@components/admin/LiveClassCard";
@@ -50,8 +51,9 @@ export default function Admin(props: AdminProps): JSX.Element {
 
     return (
         <Wrapper session={props.session}>
-            <VStack spacing={6} mx={8}>
-                <HStack spacing={4} mt={8} w="100%">
+            <AdminHeader>Dashboard</AdminHeader>
+            <VStack spacing={5} mx={8} pb={4}>
+                <HStack spacing={4} w="100%">
                     <AdminOptionButton
                         icon={MdCreate}
                         label="Create new Class"

--- a/pages/admin/program/[pid].tsx
+++ b/pages/admin/program/[pid].tsx
@@ -27,10 +27,16 @@ import { AdminLoading } from "@components/AdminLoading";
 import { Session } from "next-auth";
 import { isInternal } from "@utils/session/authorization";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { AdminHeader } from "@components/admin/AdminHeader";
 
 type ClassViewProps = {
     session: Session;
 };
+
+const headerLinks = [
+    { name: "Add Program", url: "/admin/program/create" },
+    { name: "Add Class", url: "/admin/class/create" },
+];
 
 /**
  * Admin program class view page that displays the classes of a program
@@ -75,13 +81,14 @@ export default function ProgramClassView({ session }: ClassViewProps): JSX.Eleme
 
     return (
         <Wrapper session={session}>
-            <VStack mx={8} spacing={6} mt={10} alignItems="flex-start">
+            <AdminHeader headerLinks={headerLinks}>Programs</AdminHeader>
+            <VStack mx={8} spacing={6} alignItems="flex-start">
                 <Breadcrumb separator={">"}>
                     <BreadcrumbItem>
                         <BreadcrumbLink href="/admin/program">Browse Programs</BreadcrumbLink>
                     </BreadcrumbItem>
 
-                    <BreadcrumbItem>
+                    <BreadcrumbItem isCurrentPage>
                         <BreadcrumbLink href="#" fontWeight="bold">
                             {program.name}
                         </BreadcrumbLink>

--- a/pages/admin/registrant/index.tsx
+++ b/pages/admin/registrant/index.tsx
@@ -22,6 +22,7 @@ import { GetServerSideProps } from "next";
 import { getSession } from "next-auth/client";
 import React from "react";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { AdminHeader } from "@components/admin/AdminHeader";
 
 type RegistrantViewProps = {
     session: Session;
@@ -50,9 +51,10 @@ export default function RegistrantView(props: RegistrantViewProps): JSX.Element 
 
     return (
         <Wrapper session={props.session}>
-            <VStack mx={8} spacing={8} mt={10} alignItems="flex-start">
+            <AdminHeader>Registrants</AdminHeader>
+            <VStack mx={8} spacing={8} alignItems="flex-start">
                 <Breadcrumb separator={">"}>
-                    <BreadcrumbItem>
+                    <BreadcrumbItem isCurrentPage>
                         <BreadcrumbLink href="/admin/registrant">Browse Registrants</BreadcrumbLink>
                     </BreadcrumbItem>
                 </Breadcrumb>

--- a/pages/admin/registrant/user/[id].tsx
+++ b/pages/admin/registrant/user/[id].tsx
@@ -231,7 +231,7 @@ export default function Registrant(props: AdminProps): JSX.Element {
                 <BreadcrumbItem>
                     <BreadcrumbLink href="/admin/registrant">Browse Registrants</BreadcrumbLink>
                 </BreadcrumbItem>
-                <BreadcrumbItem>
+                <BreadcrumbItem isCurrentPage>
                     <BreadcrumbLink
                         href="#"
                         fontWeight="bold"

--- a/pages/admin/user.tsx
+++ b/pages/admin/user.tsx
@@ -32,10 +32,16 @@ import { Session } from "next-auth";
 import { AdminError } from "@components/AdminError";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { errorToastOptions, infoToastOptions } from "@utils/toast/options";
+import { AdminHeader } from "@components/admin/AdminHeader";
 
 type UserViewProps = {
     session: Session;
 };
+
+const headerLinks = [
+    { name: "Add Teacher", url: "/admin/add?role=teacher" },
+    { name: "Add Admin", url: "/admin/add" },
+];
 
 /**
  * Admin registrant view page that displays all the registrants in the platform
@@ -71,7 +77,8 @@ export default function UserView(props: UserViewProps): JSX.Element {
 
     return (
         <Wrapper session={props.session}>
-            <VStack mx={8} spacing={8} mt={10} alignItems="flex-start">
+            <AdminHeader headerLinks={headerLinks}>SDC Internal</AdminHeader>
+            <VStack mx={8} spacing={6} alignItems="flex-start">
                 <Breadcrumb separator={">"}>
                     <BreadcrumbItem>
                         <BreadcrumbLink href="/admin/registrant">

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -58,7 +58,7 @@ export const AdminHeader: React.FC<AdminHeaderProps> = ({ headerLinks, children 
                     </HStack>
                 </Flex>
             </Box>
-            <Divider orientation="horizontal" my={6} border="2px" w="99%" />
+            <Divider orientation="horizontal" my={5} border="2px" w="99%" />
         </>
     );
 };


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add navbar header to all Admin pages ](https://www.notion.so/uwblueprintexecs/Add-navbar-header-to-all-Admin-pages-211e9fa33291479dab24390078479e50)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

Added AdminHeader (credits to Brandon Wong) to all admin pages as per design