### PR TITLE
fix: use DateTime instead of raw startTimeMinutes to fix timezone issue

### DIFF
--- a/pages/api/class/upcoming.ts
+++ b/pages/api/class/upcoming.ts
@@ -18,6 +18,9 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
             const todayDay = weekdayToDay(todayWeekday);
             let hasLive = false;
 
+            console.log("all classes this week:");
+            console.log(classes);
+
             // Filter classes that is further in the week or has not ended yet
             classes = classes.filter((c) => {
                 const classDay = weekdayToDay(c.weekday);
@@ -39,6 +42,9 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
                 }
             });
 
+            console.log("all classes this week 2:");
+            console.log(classes);
+
             // If today is the weekend, we include the classes for the next weekdays
             if (todayDay >= 6) {
                 let index = classes.length;
@@ -58,6 +64,9 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
                 classes = classes.slice(0, index);
                 classes.unshift(...head);
             }
+
+            console.log("all classes this week 3:");
+            console.log(classes);
 
             // Assume there is only 1 live class at all times
             const liveClass = hasLive ? classes[0] : null;

--- a/pages/api/class/upcoming.ts
+++ b/pages/api/class/upcoming.ts
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { ResponseUtil } from "@utils/responseUtil";
 import { getWeeklySortedClasses } from "@database/class";
-import { dateToWeekday, weekdayToDay } from "@utils/enum/weekday";
-import { totalMinutes } from "@utils/time/convert";
+import { totalUTCMinutes } from "@utils/time/convert";
+import { dateToPTWeekday, weekdayToDay } from "@utils/enum/weekday";
 
 /**
  * handle controls the request made to the class resource
@@ -14,26 +14,26 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
         case "GET": {
             let classes = await getWeeklySortedClasses();
             const today = new Date();
-            const todayWeekday = dateToWeekday(today);
-            const currentTimeInMinute = today.getHours() * 60 + today.getMinutes();
-            const todayDay = weekdayToDay(todayWeekday);
+            const currentTimeInUTCMinute = totalUTCMinutes(today);
+            const todayPTWeekday = dateToPTWeekday(today);
+            const todayPTDay = weekdayToDay(todayPTWeekday);
             let hasLive = false;
 
             // Filter classes that is further in the week or has not ended yet
             classes = classes.filter((c) => {
                 const classDay = weekdayToDay(c.weekday);
-                const startTimeMinutes = totalMinutes(c.startDate);
+                const startTimeUTCMinutes = totalUTCMinutes(c.startDate);
 
-                if (classDay > todayDay) {
+                if (classDay > todayPTDay) {
                     return true;
                 } else if (
-                    classDay === todayDay &&
-                    currentTimeInMinute >= startTimeMinutes &&
-                    currentTimeInMinute < startTimeMinutes + c.durationMinutes
+                    classDay === todayPTDay &&
+                    currentTimeInUTCMinute >= startTimeUTCMinutes &&
+                    currentTimeInUTCMinute < startTimeUTCMinutes + c.durationMinutes
                 ) {
                     hasLive = true;
                     return true;
-                } else if (todayDay >= 6) {
+                } else if (todayPTDay >= 6) {
                     // If today is the weekend, we include the classes for the next weekdays
                     return true;
                 } else {
@@ -42,18 +42,17 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
             });
 
             // If today is the weekend, we include the classes for the next weekdays
-            console.log("check:");
-            if (todayDay >= 6) {
-                console.log("weekday");
+            if (todayPTDay >= 6) {
                 let index = classes.length;
 
                 classes.some((c, i) => {
                     const classDay = weekdayToDay(c.weekday);
-                    const startTimeMinutes = totalMinutes(c.startDate);
+                    const startTimeUTCMinutes = totalUTCMinutes(c.startDate);
+
                     if (
-                        classDay > todayDay ||
-                        (classDay === todayDay &&
-                            currentTimeInMinute < startTimeMinutes + c.durationMinutes)
+                        classDay > todayPTDay ||
+                        (classDay === todayPTDay &&
+                            currentTimeInUTCMinute < startTimeUTCMinutes + c.durationMinutes)
                     ) {
                         index = i;
                         return true;

--- a/pages/api/enroll/child.ts
+++ b/pages/api/enroll/child.ts
@@ -183,7 +183,6 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
                                 deletedRegistration.class.weekday,
                                 deletedRegistration.class.startDate,
                                 deletedRegistration.class.endDate,
-                                deletedRegistration.class.startTimeMinutes,
                                 deletedRegistration.class.durationMinutes,
                                 record.parent.preferredLanguage,
                             ),

--- a/pages/api/mail/index.ts
+++ b/pages/api/mail/index.ts
@@ -81,7 +81,6 @@ function pushMailPromises(classes, intervalHours: number, mailerPromises: Promis
                         weekday,
                         startDate,
                         endDate,
-                        startTimeMinutes,
                         durationMinutes,
                         reg.parent.preferredLanguage,
                     ),
@@ -105,7 +104,6 @@ function pushMailPromises(classes, intervalHours: number, mailerPromises: Promis
                         weekday,
                         startDate,
                         endDate,
-                        startTimeMinutes,
                         durationMinutes,
                         reg.volunteer.preferredLanguage
                             ? reg.volunteer.preferredLanguage

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ model Class {
   startDate           DateTime           @map("start_date") @db.Timestamptz(6)
   endDate             DateTime           @map("end_date") @db.Timestamptz(6)
   weekday             weekday
-  startTimeMinutes    Int                @map("start_time_minutes")
+  startTimeMinutes    Int                @map("start_time_minutes")  // @deprecated TODO: remove
   durationMinutes     Int                @map("duration_minutes")
   createdAt           DateTime           @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime?          @map("updated_at") @db.Timestamptz(6)

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -78,7 +78,7 @@ CREATE TABLE classes (
   start_date TIMESTAMPTZ NOT NULL,
   end_date TIMESTAMPTZ NOT NULL,
   weekday weekdays NOT NULL,
-  start_time_minutes INTEGER NOT NULL,
+  start_time_minutes INTEGER NOT NULL, -- deprecated TODO: remove
   duration_minutes INTEGER NOT NULL,
 
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/services/database/class.ts
+++ b/services/database/class.ts
@@ -2,6 +2,8 @@ import prisma from "@database";
 import { Class } from "@prisma/client";
 import { ClassInput, ClassTranslationInput } from "@models/Class";
 import { stripe } from "services/stripe";
+import { totalMinutes } from "@utils/time/convert";
+import { weekdayToDay } from "@utils/enum/weekday";
 /**
  * getClass takes the id parameter and returns the class associated with the classId
  * @param {string} id - classId
@@ -85,14 +87,15 @@ async function getWeeklySortedClasses() {
                 },
             },
         },
-        orderBy: [
-            {
-                weekday: "asc",
-            },
-            {
-                startTimeMinutes: "asc",
-            },
-        ],
+    });
+
+    // To manual sort due to sorting property of startDate
+    classes.sort((x, y) => {
+        if (x.weekday === y.weekday) {
+            return totalMinutes(x.startDate) - totalMinutes(y.startDate);
+        } else {
+            return weekdayToDay(x.weekday) - weekdayToDay(y.weekday);
+        }
     });
     return classes;
 }

--- a/src/components/ClassInfoCard.tsx
+++ b/src/components/ClassInfoCard.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import colourTheme from "@styles/colours";
 import useMe from "@utils/hooks/useMe";
 import { AgeBadge } from "./AgeBadge";
+import { totalMinutes } from "@utils/time/convert";
 
 type ClassInfoProps = {
     cardInfo: ClassCardInfo;
@@ -77,7 +78,7 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
                                 day: weekdayToString(cardInfo.weekday, router.locale as locale),
                             })}{" "}
                             {convertToShortTimeRange(
-                                cardInfo.startTimeMinutes,
+                                totalMinutes(cardInfo.startDate),
                                 cardInfo.durationMinutes,
                             )}
                             {" with " +

--- a/src/components/ClassInfoModal.tsx
+++ b/src/components/ClassInfoModal.tsx
@@ -29,6 +29,7 @@ import { useRouter } from "next/router";
 import { locale, roles } from "@prisma/client";
 import { UseMeResponse } from "@utils/hooks/useMe";
 import { infoToastOptions } from "@utils/toast/options";
+import { totalMinutes } from "@utils/time/convert";
 
 type ClassInfoModalProps = {
     isOpen: boolean;
@@ -105,7 +106,7 @@ export const ClassInfoModal: React.FC<ClassInfoModalProps> = ({
                                     ),
                                 })}{" "}
                                 {convertToShortTimeRange(
-                                    classInfo.startTimeMinutes,
+                                    totalMinutes(classInfo.startDate),
                                     classInfo.durationMinutes,
                                 )}
                             </Text>

--- a/src/components/EnrollmentCard.tsx
+++ b/src/components/EnrollmentCard.tsx
@@ -32,6 +32,7 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { locale } from "@prisma/client";
 import useGetZoomLink from "@utils/hooks/useGetZoomLink";
+import { totalMinutes } from "@utils/time/convert";
 
 type EnrollmentCardProps = {
     enrollmentInfo: CombinedEnrollmentCardInfo;
@@ -111,7 +112,7 @@ export const EnrollmentCard: React.FC<EnrollmentCardProps> = ({
                                         ),
                                     })}{" "}
                                     {convertToShortTimeRange(
-                                        enrollmentInfo.class.startTimeMinutes,
+                                        totalMinutes(enrollmentInfo.class.startDate),
                                         enrollmentInfo.class.durationMinutes,
                                     )}
                                     {" with " +

--- a/src/components/FormClass.tsx
+++ b/src/components/FormClass.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "next-i18next";
 import { locale } from "@prisma/client";
 import { ClassCardInfo } from "@models/Class";
 import { AgeBadge } from "./AgeBadge";
+import { totalMinutes } from "@utils/time/convert";
 
 type FormClassCardProps = {
     classInfo: ClassCardInfo;
@@ -52,7 +53,7 @@ export const FormClassCard: React.FC<FormClassCardProps> = ({ classInfo }) => {
                                         ),
                                     })}{" "}
                                     {convertToShortTimeRange(
-                                        classInfo.startTimeMinutes,
+                                        totalMinutes(classInfo.startDate),
                                         classInfo.durationMinutes,
                                     )}
                                     {" with " +

--- a/src/components/VolunteeringCard.tsx
+++ b/src/components/VolunteeringCard.tsx
@@ -29,6 +29,7 @@ import { useRouter } from "next/router";
 import { locale } from "@prisma/client";
 import { useTranslation } from "next-i18next";
 import useGetZoomLink from "@utils/hooks/useGetZoomLink";
+import { totalMinutes } from "@utils/time/convert";
 
 type VolunteeringCardProps = {
     volunteeringInfo: VolunteeringCardInfo;
@@ -72,7 +73,7 @@ export const VolunteeringCard: React.FC<VolunteeringCardProps> = ({ volunteering
                                         ),
                                     })}{" "}
                                     {convertToShortTimeRange(
-                                        volunteeringInfo.class.startTimeMinutes,
+                                        totalMinutes(volunteeringInfo.class.startDate),
                                         volunteeringInfo.class.durationMinutes,
                                     )}
                                     {" with " +

--- a/src/components/WaitlistCard.tsx
+++ b/src/components/WaitlistCard.tsx
@@ -21,6 +21,7 @@ import { deleteWaitlistRegistration } from "@utils/deleteWaitlistRegistration";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { locale } from "@prisma/client";
+import { totalMinutes } from "@utils/time/convert";
 
 type WaitlistCardProps = {
     waitlistInfo: WaitlistCardInfo;
@@ -62,7 +63,7 @@ export const WaitlistCard: React.FC<WaitlistCardProps> = ({ waitlistInfo }) => {
                                         ),
                                     })}{" "}
                                     {convertToShortTimeRange(
-                                        waitlistInfo.class.startTimeMinutes,
+                                        totalMinutes(waitlistInfo.class.startDate),
                                         waitlistInfo.class.durationMinutes,
                                     )}
                                     {" with " +

--- a/src/components/admin/ArchivedProgramClassInfoCard.tsx
+++ b/src/components/admin/ArchivedProgramClassInfoCard.tsx
@@ -28,6 +28,7 @@ import colourTheme from "@styles/colours";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
 import { deleteClass } from "@utils/deleteClass";
 import { weekdayToString } from "@utils/enum/weekday";
+import { totalMinutes } from "@utils/time/convert";
 import { infoToastOptions } from "@utils/toast/options";
 import { updateClassArchive } from "@utils/updateClassArchive";
 import Link from "next/link";
@@ -131,7 +132,7 @@ export const ArchivedProgramClassInfoCard: React.FC<ArchivedProgramClassInfoCard
                             >
                                 {weekdayToString(cardInfo.weekday, locale.en)}{" "}
                                 {convertToShortTimeRange(
-                                    cardInfo.startTimeMinutes,
+                                    totalMinutes(cardInfo.startDate),
                                     cardInfo.durationMinutes,
                                 )}
                                 {" with Teacher " + cardInfo.teacherName}

--- a/src/components/admin/ClassViewInfoCard.tsx
+++ b/src/components/admin/ClassViewInfoCard.tsx
@@ -30,6 +30,7 @@ import React from "react";
 import { IoEllipsisVertical } from "react-icons/io5";
 import { AdminModal } from "./AdminModal";
 import { infoToastOptions } from "@utils/toast/options";
+import { totalMinutes } from "@utils/time/convert";
 
 export type ClassViewInfoCard = {
     cardInfo: ClassCardInfo;
@@ -113,7 +114,7 @@ export const ClassViewInfoCard: React.FC<ClassViewInfoCard> = ({ cardInfo, role 
                             <Box as="span" color={colourTheme.colors.Gray} fontSize="sm">
                                 {weekdayToString(cardInfo.weekday, locale.en)}{" "}
                                 {convertToShortTimeRange(
-                                    cardInfo.startTimeMinutes,
+                                    totalMinutes(cardInfo.startDate),
                                     cardInfo.durationMinutes,
                                 )}
                             </Box>

--- a/src/components/admin/LiveClassCard.tsx
+++ b/src/components/admin/LiveClassCard.tsx
@@ -4,6 +4,7 @@ import { PrimaryButton } from "@components/SDCButton";
 import { ClassCardInfo } from "@models/Class";
 import colourTheme from "@styles/colours";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
+import { totalMinutes } from "@utils/time/convert";
 import { useRouter } from "next/router";
 import React from "react";
 
@@ -33,7 +34,10 @@ export const LiveClassCard: React.FC<LiveClassCardProps> = ({ cardInfo, link }) 
                     {cardInfo.programName} ({cardInfo.name})
                 </Heading>
                 <Text color={colourTheme.colors.Gray} fontSize="sm">
-                    {convertToShortTimeRange(cardInfo.startTimeMinutes, cardInfo.durationMinutes)}
+                    {convertToShortTimeRange(
+                        totalMinutes(cardInfo.startDate),
+                        cardInfo.durationMinutes,
+                    )}
                     {" with Teacher " + cardInfo.teacherName}
                 </Text>
                 <Text color={colourTheme.colors.Gray} fontSize="sm">

--- a/src/components/admin/ProgramClassInfoCard.tsx
+++ b/src/components/admin/ProgramClassInfoCard.tsx
@@ -28,6 +28,7 @@ import colourTheme from "@styles/colours";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
 import { deleteClass } from "@utils/deleteClass";
 import { weekdayToString } from "@utils/enum/weekday";
+import { totalMinutes } from "@utils/time/convert";
 import { infoToastOptions } from "@utils/toast/options";
 import { updateClassArchive } from "@utils/updateClassArchive";
 import Link from "next/link";
@@ -131,7 +132,7 @@ export const ProgramClassInfoCard: React.FC<ProgramClassInfoCard> = ({
                             >
                                 {weekdayToString(cardInfo.weekday, locale.en)}{" "}
                                 {convertToShortTimeRange(
-                                    cardInfo.startTimeMinutes,
+                                    totalMinutes(cardInfo.startDate),
                                     cardInfo.durationMinutes,
                                 )}
                                 {" with Teacher " + cardInfo.teacherName}

--- a/src/components/admin/UpcomingClassCard.tsx
+++ b/src/components/admin/UpcomingClassCard.tsx
@@ -16,6 +16,7 @@ import { ClassCardInfo } from "@models/Class";
 import colourTheme from "@styles/colours";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
 import { weekdayToString } from "@utils/enum/weekday";
+import { totalMinutes } from "@utils/time/convert";
 import { useRouter } from "next/router";
 import React from "react";
 
@@ -59,7 +60,7 @@ export const UpcomingClassCard: React.FC<UpcomingClassCardProps> = ({ cardInfo }
                         <Box as="span" color={colourTheme.colors.Gray} fontSize="sm">
                             {weekdayToString(cardInfo.weekday, locale.en)}{" "}
                             {convertToShortTimeRange(
-                                cardInfo.startTimeMinutes,
+                                totalMinutes(cardInfo.startDate),
                                 cardInfo.durationMinutes,
                             )}
                         </Box>

--- a/utils/cardInfoUtil.ts
+++ b/utils/cardInfoUtil.ts
@@ -3,6 +3,7 @@ import { ClassCardInfo } from "models/Class";
 import { EnrollmentCardInfo, VolunteeringCardInfo, WaitlistCardInfo } from "@models/Enroll";
 import { ClassTranslation, locale, ProgramTranslation } from "@prisma/client";
 import { TranslationUtil } from "./translationUtil";
+import { totalMinutes } from "./time/convert";
 
 // Converting Program and Class information from services/database/program-card-info.ts
 // into Program/Class CardInfo objects for frontend
@@ -31,6 +32,7 @@ export class CardInfoUtil {
         );
         const mainProgramTranslation: ProgramTranslation =
             TranslationUtil.getMainProgramTranslation(result.program.programTranslation, language);
+
         return {
             borderAge: result.borderAge,
             isAgeMinimal: result.isAgeMinimal,
@@ -43,8 +45,8 @@ export class CardInfoUtil {
             volunteerSpaceTotal: result.volunteerSpaceTotal,
             volunteerSpaceAvailable: result.volunteerSpaceTotal - result._count?.volunteerRegs,
             volunteerSpaceTaken: result._count?.volunteerRegs,
-            startDate: result.startDate,
-            endDate: result.endDate,
+            startDate: new Date(result.startDate),
+            endDate: new Date(result.endDate),
             weekday: result.weekday,
             startTimeMinutes: result.startTimeMinutes,
             durationMinutes: result.durationMinutes,

--- a/utils/enum/weekday.ts
+++ b/utils/enum/weekday.ts
@@ -29,6 +29,7 @@ export function weekdayToString(wd: weekday, language: locale = locale.en): stri
             return "Invalid weekday";
     }
 }
+
 /**
  * Method for returning weekday enum given date
  * @param  {Date} date
@@ -55,6 +56,42 @@ export function dateToWeekday(date: Date): weekday {
     }
 }
 
+/**
+ * Method for returning PT weekday enum given date
+ * @param  {Date} date
+ * @returns weekday
+ */
+export function dateToPTWeekday(date: Date): weekday {
+    // Convert UTC to PT date
+    const utcDate = new Date(date.toUTCString());
+    utcDate.setHours(utcDate.getHours() - 8);
+    const ptDate = new Date(utcDate);
+
+    switch (ptDate.getUTCDay()) {
+        case 0:
+            return weekday.SUN;
+        case 1:
+            return weekday.MON;
+        case 2:
+            return weekday.TUE;
+        case 3:
+            return weekday.WED;
+        case 4:
+            return weekday.THU;
+        case 5:
+            return weekday.FRI;
+        case 6:
+            return weekday.SAT;
+        default:
+            return weekday.MON;
+    }
+}
+
+/**
+ * Method for converting weekday enum to number for comparison
+ * @param  {weekday} wd
+ * @returns number
+ */
 export function weekdayToDay(wd: weekday): number {
     switch (wd) {
         case weekday.MON:

--- a/utils/mail/templateUtil.ts
+++ b/utils/mail/templateUtil.ts
@@ -2,6 +2,7 @@ import { locale, weekday } from "@prisma/client";
 import convertToShortDateRange from "@utils/convertToShortDateRange";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
 import { weekdayToString } from "@utils/enum/weekday";
+import { totalMinutes } from "@utils/time/convert";
 
 /**
  * Return html representing the class notification template
@@ -9,9 +10,8 @@ import { weekdayToString } from "@utils/enum/weekday";
  * @param  {string} imageLink image link of class
  * @param  {string} name name of class
  * @param  {weekday} classWeekday repeated weekday of class
- * @param  {Date} startDate date which class starts
+ * @param  {Date} startDate date time which class starts
  * @param  {Date} endDate date which class ends
- * @param  {number} startTimeMinutes starting time in minutes
  * @param  {number} durationMinutes duration of session
  * @return {string} html template
  */
@@ -22,7 +22,6 @@ export const classStartingSoonTemplate = (
     classWeekday: weekday,
     startDate: Date,
     endDate: Date,
-    startTimeMinutes: number,
     durationMinutes: number,
     language: locale = locale.en,
 ): string => {
@@ -67,7 +66,7 @@ export const classStartingSoonTemplate = (
                         ><br /><span
                             style="width: 30px; color: rgba(115, 115, 115, 1); font-size: 14px"
                             >${weekdayToString(classWeekday, language)} ${convertToShortTimeRange(
-        startTimeMinutes,
+        totalMinutes(startDate),
         durationMinutes,
     )}</span
                         ><br /><span
@@ -91,9 +90,8 @@ export const classStartingSoonTemplate = (
  * @param  {string} imageLink image link of class
  * @param  {string} name name of class
  * @param  {weekday} classWeekday repeated weekday of class
- * @param  {Date} startDate date which class starts
+ * @param  {Date} startDate date time which class starts
  * @param  {Date} endDate date which class ends
- * @param  {number} startTimeMinutes starting time in minutes
  * @param  {number} durationMinutes duration of session
  * @return {string} html template
  */
@@ -104,7 +102,6 @@ export const openSpotWaitlistTemplate = (
     classWeekday: weekday,
     startDate: Date,
     endDate: Date,
-    startTimeMinutes: number,
     durationMinutes: number,
     language: locale = locale.en,
 ): string => {
@@ -149,7 +146,7 @@ export const openSpotWaitlistTemplate = (
                         ><br /><span
                             style="width: 30px; color: rgba(115, 115, 115, 1); font-size: 14px"
                             >${weekdayToString(classWeekday, language)} ${convertToShortTimeRange(
-        startTimeMinutes,
+        totalMinutes(startDate),
         durationMinutes,
     )}</span
                         ><br /><span

--- a/utils/time/convert.ts
+++ b/utils/time/convert.ts
@@ -6,3 +6,12 @@
 export function totalMinutes(date: Date): number {
     return date.getMinutes() + date.getHours() * 60;
 }
+
+/**
+ * totalUTCMinutes gets the total minutes of a time in a date in UTC
+ * @param  {Date} date
+ * @returns number
+ */
+export function totalUTCMinutes(date: Date): number {
+    return date.getMinutes() + date.getHours() * 60;
+}

--- a/utils/time/convert.ts
+++ b/utils/time/convert.ts
@@ -1,0 +1,8 @@
+/**
+ * totalMinutes gets the total minutes of a time in a date, counting hours in minutes
+ * @param  {Date} date
+ * @returns number
+ */
+export function totalMinutes(date: Date): number {
+    return date.getMinutes() + date.getHours() * 60;
+}


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[BUG: In deployment, live classes and upcoming classes on current day is not showing up on dashboard](https://www.notion.so/uwblueprintexecs/BUG-In-deployment-live-classes-and-upcoming-classes-on-current-day-is-not-showing-up-on-dashboard-031332e620fc41f7ba42738993b8e1ab)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

![image](https://user-images.githubusercontent.com/44826218/144730766-e4a7c044-ed3d-42b7-9f44-ea92e2bb09dc.png)

- Use startDate.getMinutes and startDate.getHours to get startTime Instead.
- Use UTC date comparison where possible. Use PTDay comparisons for backend.
  - We need this since dates are inserted into prisma as UTC time and we cannot do `new Date()` as it depends on where the host machine is. We get around this by always getting UTC times from the date object.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go into deploy branch, log in as admin and test dashboard with live class and upcoming class for today. Classes should show up as expected.

### Next Steps

-   [ ] Remove the deprecated startTimeMinutes field from DB. The query order by startTimeMinutes query might be a bit difficult.