### PR TITLE
feat(archive-class): remove link to unarchived page + query only unarchived class by default

### DIFF
--- a/pages/api/class/[id].ts
+++ b/pages/api/class/[id].ts
@@ -14,8 +14,10 @@ import { getSession } from "next-auth/client";
  */
 export default async function handle(req: NextApiRequest, res: NextApiResponse): Promise<void> {
     // Obtain class id
-    const { id } = req.query;
+    const { id, includeArchived } = req.query;
     const session = await getSession({ req });
+
+    const includeArchivedParsed = Boolean(JSON.parse((includeArchived as string) || "false"));
 
     //parse query parameters from string to number and validate that id is a number
     const classId = parseInt(id as string, 10);
@@ -24,8 +26,13 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse):
     }
 
     if (req.method == "GET") {
+        // include archived should be admin only
+        if (includeArchivedParsed && !isAdmin(session)) {
+            return ResponseUtil.returnUnauthorized(res, "Unauthorized");
+        }
+
         // obtain class with provided classId
-        const classSection = await getClass(classId);
+        const classSection = await getClass(classId, includeArchivedParsed);
 
         if (!classSection) {
             ResponseUtil.returnNotFound(res, `Class with id ${classId} not found.`);

--- a/services/database/class.ts
+++ b/services/database/class.ts
@@ -4,13 +4,21 @@ import { ClassInput } from "@models/Class";
 /**
  * getClass takes the id parameter and returns the class associated with the classId
  * @param {string} id - classId
+ * @param {boolean} includeArchived - include archived classes as well
  *
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-async function getClass(id: number) {
-    const classSection = await prisma.class.findUnique({
+async function getClass(id: number, includeArchived = false) {
+    const classSection = await prisma.class.findFirst({
         where: {
             id,
+            ...(() => {
+                return includeArchived
+                    ? undefined
+                    : {
+                          isArchived: false,
+                      };
+            })(),
         },
         include: {
             program: { include: { programTranslation: true } },

--- a/src/components/admin/ArchivedProgramClassInfoCard.tsx
+++ b/src/components/admin/ArchivedProgramClassInfoCard.tsx
@@ -88,11 +88,7 @@ export const ArchivedProgramClassInfoCard: React.FC<ArchivedProgramClassInfoCard
                 <GridItem colSpan={4} p={1}>
                     <VStack align="left" justify="center" height="100%">
                         <Flex mr="3" alignItems="baseline">
-                            <Link href={`/admin/class/${cardInfo.id}`}>
-                                <ChakraLink>
-                                    <Heading size="md">{cardInfo.name}</Heading>
-                                </ChakraLink>
-                            </Link>
+                            <Heading size="md">{cardInfo.name}</Heading>
                             <Spacer />
                             {role !== roles.PROGRAM_ADMIN ? null : (
                                 <Menu>

--- a/utils/hooks/useClass.ts
+++ b/utils/hooks/useClass.ts
@@ -2,7 +2,7 @@ import { ClassCardInfo } from "@models/Class";
 import { locale } from "@prisma/client";
 import CardInfoUtil from "@utils/cardInfoUtil";
 import useSWR from "swr";
-import { fetcher } from "../fetcher";
+import { fetcherWithQuery } from "../fetcher";
 
 export type UseClassResponse = {
     classCard: ClassCardInfo;
@@ -14,10 +14,18 @@ export type UseClassResponse = {
  * use Class hook to get class info given id
  * @param  {string} id class id
  * @param  {locale} language language of class translation to get
+ * @param  {boolean} includeArchived whether or not to include archived class (admin only)
  * @returns UseClassResponse
  */
-export default function useClass(id: string, language: locale): UseClassResponse {
-    const { data, error } = useSWR(`/api/class/${id}`, fetcher);
+export default function useClass(
+    id: string,
+    language: locale,
+    includeArchived = false,
+): UseClassResponse {
+    const { data, error } = useSWR(
+        [`/api/class/${id}`, includeArchived, "includeArchived"],
+        fetcherWithQuery,
+    );
     const classCard = data?.data ? CardInfoUtil.getClassCardInfo(data.data, language) : null;
     return {
         classCard,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove archived class link to unarchived class details](https://www.notion.so/uwblueprintexecs/Remove-archived-class-link-to-unarchived-class-details-b66555684923468f802c85ab2b20e8dd)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Remove link to unarchived class details page in archived class tabs
![image](https://user-images.githubusercontent.com/44826218/144771708-5fa5c83d-3a13-4fff-90ed-88da851848a3.png)
- Edit query to have option to include archived class (admin api only) @GodGreg you will need to enable this option for editing classes in case we are editing an archived class.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Link is removed, no longer clickable

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Design: correctness of removing the link from archived class page
- Dev: query change

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
