### PR TITLE
feat(admin): upcoming classes page

### DIFF
--- a/pages/admin/archive/index.tsx
+++ b/pages/admin/archive/index.tsx
@@ -135,11 +135,7 @@ export const ArchiveBrowsePrograms: React.FC<ArchiveBrowseProgramsProps> = (prop
                                 </Grid>
                             ) : (
                                 <Box>
-                                    <AdminEmptyState
-                                        w="100%"
-                                        h="250px"
-                                        isLoading={isProgramsLoading}
-                                    >
+                                    <AdminEmptyState w="100%" h="250px" isLoading={isClassLoading}>
                                         There are no classes archived!
                                     </AdminEmptyState>
                                 </Box>

--- a/pages/admin/class/[id].tsx
+++ b/pages/admin/class/[id].tsx
@@ -33,8 +33,8 @@ type ClassViewProps = {
 };
 
 const headerLinks = [
-    { name: "Add Program", url: "/admin/program/create" },
-    { name: "Add Class", url: "/admin/class/create" },
+    { name: "Add Program", url: "/admin/program/edit/new" },
+    { name: "Add Class", url: "/admin/class/edit/new" },
 ];
 
 /**

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -125,7 +125,7 @@ export default function Admin(props: AdminProps): JSX.Element {
                         <Flex mb={5}>
                             Upcoming Classes
                             <Spacer />
-                            <Link href="/admin/program">
+                            <Link href="/admin/upcoming">
                                 <ChakraLink color={colourTheme.colors.Blue}>
                                     See all
                                     <ArrowForwardIcon ml={4} />

--- a/pages/admin/program/[pid].tsx
+++ b/pages/admin/program/[pid].tsx
@@ -34,8 +34,8 @@ type ClassViewProps = {
 };
 
 const headerLinks = [
-    { name: "Add Program", url: "/admin/program/create" },
-    { name: "Add Class", url: "/admin/class/create" },
+    { name: "Add Program", url: "/admin/program/edit/new" },
+    { name: "Add Class", url: "/admin/class/edit/new" },
 ];
 
 /**

--- a/pages/admin/upcoming.tsx
+++ b/pages/admin/upcoming.tsx
@@ -1,0 +1,138 @@
+import { SearchIcon } from "@chakra-ui/icons";
+import { Box, Grid, GridItem, Input, InputGroup, InputLeftElement } from "@chakra-ui/react";
+import { AdminEmptyState } from "@components/admin/AdminEmptyState";
+import { AdminHeader } from "@components/admin/AdminHeader";
+import { ProgramClassInfoCard } from "@components/admin/ProgramClassInfoCard";
+import { AdminError } from "@components/AdminError";
+import { AdminLoading } from "@components/AdminLoading";
+import Wrapper from "@components/AdminWrapper";
+import { locale } from "@prisma/client";
+import { weekdayToString } from "@utils/enum/weekday";
+import useUpcomingClasses from "@utils/hooks/useUpcomingClasses";
+import { isInternal } from "@utils/session/authorization";
+import { GetServerSideProps } from "next";
+import { Session } from "next-auth";
+import { getSession } from "next-auth/client";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
+import { mutate } from "swr";
+
+type BrowseUpcomingProps = {
+    session: Session;
+};
+
+export const BrowseUpcoming: React.FC<BrowseUpcomingProps> = (props) => {
+    const router = useRouter();
+    const [searchClassTerm, setSearchClassTerm] = useState("");
+
+    const {
+        liveClass,
+        upcomingClasses,
+        isLoading: isClassLoading,
+        error: classError,
+    } = useUpcomingClasses(router.locale as locale);
+
+    const classCards = [liveClass].concat(upcomingClasses);
+
+    if (classError) {
+        return <AdminError cause="could not fetch upcoming classes" />;
+    } else if (isClassLoading) {
+        return <AdminLoading />;
+    }
+
+    const filteredClassCards = classCards.filter((classCard) => {
+        const term = searchClassTerm.toLowerCase();
+        if (term == "") {
+            return classCard;
+        } else if (
+            classCard.name.toLowerCase().includes(term) ||
+            classCard.description.toLowerCase().includes(term) ||
+            classCard.teacherName.toLowerCase().includes(term) ||
+            weekdayToString(classCard.weekday, locale.en).toLowerCase().includes(term)
+        ) {
+            return classCard;
+        }
+    });
+
+    return (
+        <Wrapper session={props.session}>
+            <AdminHeader>Upcoming Classes</AdminHeader>
+            <Box mx={6}>
+                <Box>
+                    <InputGroup mt="25px">
+                        <InputLeftElement
+                            pointerEvents="none"
+                            children={<SearchIcon color="gray.300" />}
+                        />
+                        <Input
+                            pl={8}
+                            placeholder={"Search Classes"}
+                            onChange={(e) => {
+                                setSearchClassTerm(e.target.value);
+                            }}
+                        />
+                    </InputGroup>
+                </Box>
+
+                <Box mt="25px">
+                    {filteredClassCards && filteredClassCards.length > 0 ? (
+                        <Grid templateColumns="repeat(2, 1fr)" gap={4}>
+                            {filteredClassCards.map((item, idx) => {
+                                return (
+                                    <GridItem key={idx}>
+                                        <ProgramClassInfoCard
+                                            cardInfo={item}
+                                            role={props.session.role}
+                                            mutateClasses={() =>
+                                                mutate(["/api/class", true, "archived"])
+                                            }
+                                        />
+                                    </GridItem>
+                                );
+                            })}
+                        </Grid>
+                    ) : (
+                        <Box>
+                            <AdminEmptyState w="100%" h="250px" isLoading={isClassLoading}>
+                                There are no upcoming classes!
+                            </AdminEmptyState>
+                        </Box>
+                    )}
+                </Box>
+            </Box>
+        </Wrapper>
+    );
+};
+
+export default BrowseUpcoming;
+
+/**
+ * getServerSideProps gets the session before this page is rendered
+ */
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    // obtain the next auth session
+    const session = await getSession(context);
+    if (!session) {
+        return {
+            redirect: {
+                destination: "/login",
+                permanent: false,
+            },
+        };
+    } else if (!isInternal(session)) {
+        return {
+            redirect: {
+                destination: "/no-access",
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {
+            session,
+            ...(await serverSideTranslations(context.locale, ["common"])),
+        },
+    };
+};


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create Upcoming Classes page](https://www.notion.so/uwblueprintexecs/Create-Upcoming-Classes-page-8a68c9402dca47699dc841f92deba8c7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

https://user-images.githubusercontent.com/44826218/145700048-a19a4f05-7ea0-4918-b53c-aab9c3053944.mp4


- Add upcoming page, similar exactly the same as browse archived class page but without tab and get api from existing /api/upcoming route
- Fix some links to go to the right page

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Have classes from multiple programs. and ensure they show up in order
2. edit/archive/delete classes in this page should work

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Design: look and feel

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
