### PR TITLE
fix(edit/class): useEffect depends on user query

### DIFF
--- a/pages/admin/class/edit/[id].tsx
+++ b/pages/admin/class/edit/[id].tsx
@@ -93,7 +93,7 @@ export default function CreateClass({ session }: Props): JSX.Element {
     } = useStripePrice(classCard?.stripePriceId);
 
     useEffect(() => {
-        if (classCard && programs && !isClassLoad) {
+        if (classCard && programs && !isClassLoad && teachers) {
             setClassName(classCard.name);
             setAssociatedProgram(classCard.programName);
 
@@ -119,7 +119,7 @@ export default function CreateClass({ session }: Props): JSX.Element {
             setDurationMinutes(classCard.durationMinutes.toString());
             setIsClassLoad(true);
         }
-    }, [classCard]);
+    }, [classCard, teachers]);
 
     useEffect(() => {
         if (stripePrice && !isPriceLoad) {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Edit Class Teacher Does not load in time](https://www.notion.so/uwblueprintexecs/Edit-Class-Teacher-Does-not-load-in-time-4b7a97ff31914f8bb026798938697d8c)

When loading the edit class page, the teacher field does not populate on the first try when cache is empty. The useEffect is not complete, it needs to depend on the useUsers query.