### PR TITLE
fix(program-details): volunteer spots prog details instead of participant

### DIFF
--- a/src/components/ClassInfoCard.tsx
+++ b/src/components/ClassInfoCard.tsx
@@ -90,8 +90,9 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
                         <Box mr="3" as="span" color="gray.600" fontSize="sm">
                             {me && me.role === roles.VOLUNTEER
                                 ? t("program.volunteerSpot", {
-                                      spot: cardInfo.spaceAvailable,
-                                      context: cardInfo.spaceAvailable !== 1 ? "plural" : "",
+                                      spot: cardInfo.volunteerSpaceAvailable,
+                                      context:
+                                          cardInfo.volunteerSpaceAvailable !== 1 ? "plural" : "",
                                   })
                                 : t("program.participantSpot", {
                                       spot: cardInfo.spaceAvailable,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Volunteer Program Details Shows Participant Spots Available as "volunteer spots available"](https://www.notion.so/uwblueprintexecs/Volunteer-Program-Details-Shows-Participant-Spots-Available-as-volunteer-spots-available-921f2c818cd749ccaa563ad61dc4189c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Use volunteerSpaceAvailable instead of spaceAvailable

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Make sure that full/available classes for volunteer shows in the right section (available/full)


### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
