### PR TITLE
fix(prisma-query): parent query order students id

### DIFF
--- a/services/database/user.ts
+++ b/services/database/user.ts
@@ -17,7 +17,11 @@ async function getUser(id: string) {
             teacher: true,
             parent: {
                 include: {
-                    students: true,
+                    students: {
+                        orderBy: {
+                            id: "asc",
+                        },
+                    },
                 },
             },
             programAdmin: true,
@@ -41,7 +45,11 @@ async function getUserFromEmail(email: string) {
             teacher: true,
             parent: {
                 include: {
-                    students: true,
+                    students: {
+                        orderBy: {
+                            id: "asc",
+                        },
+                    },
                 },
             },
             programAdmin: true,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make Participant Reordering Consistent via id ordering rather than lastUpdated ordering](https://www.notion.so/uwblueprintexecs/Make-Participant-Reordering-Consistent-via-id-ordering-rather-than-lastUpdated-ordering-4d1363c123304faf8299734e52cbe2ed)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- order queried students by id instead of updatedAt

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go the the my account page for parents. When editing multiple students for that parent, the order of the students in the sidebar should never change, it should be ordered which they are added
2. Go to the registrant profile page for a parent in the internal platform. Similarly, editing students of a parent here should not change order of students.

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
