### PR TITLE
fix(external enroll): no dup enrollment

### DIFF
--- a/pages/class.tsx
+++ b/pages/class.tsx
@@ -43,7 +43,7 @@ function Class({ session }: ClassProps): JSX.Element {
 
     return (
         <Wrapper session={session}>
-            <BackButton />
+            <BackButton onClick={() => router.push("/")} />
             <Flex direction="column" pt={4} pb={8}>
                 <Flex align="center">
                     <Heading mb={8}>{t("nav.myClasses")}</Heading>

--- a/pages/parent/enrollment.tsx
+++ b/pages/parent/enrollment.tsx
@@ -25,6 +25,7 @@ import useSWR from "swr";
 import { Session } from "next-auth";
 import convertToAge from "@utils/convertToAge";
 import { useTranslation } from "next-i18next";
+import useParentRegistrations from "@utils/hooks/useParentRegistration";
 
 type ParentEnrollClassProps = {
     session: Session;
@@ -51,11 +52,17 @@ export default function ParentEnrollClass({ session }: ParentEnrollClassProps): 
         fetcherWithQuery,
     );
 
+    const {
+        enrollments,
+        isLoading: isRegistrationsLoading,
+        error: registrationsError,
+    } = useParentRegistrations(router.locale as locale);
+
     const isClassInfoLoading = !classInfoResponse && !classInfoError;
 
-    if (classInfoError) {
+    if (classInfoError || registrationsError) {
         return <CommonError session={session} cause="cannot fetch class" />;
-    } else if (isClassInfoLoading) {
+    } else if (isClassInfoLoading || isRegistrationsLoading) {
         return <CommonLoading session={session} />;
     }
 
@@ -99,9 +106,12 @@ export default function ParentEnrollClass({ session }: ParentEnrollClassProps): 
     });
 
     const studentEligible = studentData.map((s) => {
-        return classInfo.isAgeMinimal
-            ? convertToAge(s.dateOfBirth) >= classInfo.borderAge
-            : convertToAge(s.dateOfBirth) <= classInfo.borderAge;
+        return (
+            enrollments.every((enroll) => enroll.student.id !== s.id) &&
+            (classInfo.isAgeMinimal
+                ? convertToAge(s.dateOfBirth) >= classInfo.borderAge
+                : convertToAge(s.dateOfBirth) <= classInfo.borderAge)
+        );
     });
 
     const ageRange = t(classInfo.isAgeMinimal ? "program.ageGroupAbove" : "program.ageGroupUnder", {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ability to Register for a class after you've already registered ](https://www.notion.so/uwblueprintexecs/Ability-to-Register-for-a-class-after-you-ve-already-registered-c632e8ba9ae64e4c93d0ad0c32803d4c)
[Volunteer: After registering for a class the back button is incorrect](https://www.notion.so/uwblueprintexecs/Volunteer-After-registering-for-a-class-the-back-button-is-incorrect-0a15045ee8214dbd9c4ea493a9712253)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- For enrollment page of volunteer, query volunteer regs for user and if user already registered, go to classes pgae
- For enrollment page of parent, query student regs for user and make student not eligible if they are already in class
- We also changed the back button in the my classes page to go to home page instead

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Try to enroll in a class twice as parent or volunteer. You should not be able to.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Dev: Logic of query

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
