### PR TITLE
fix(internal/browse): fix width styling for cards

### DIFF
--- a/src/components/admin/ClassViewInfoCard.tsx
+++ b/src/components/admin/ClassViewInfoCard.tsx
@@ -71,6 +71,7 @@ export const ClassViewInfoCard: React.FC<ClassViewInfoCard> = ({ cardInfo, role 
                 minH={165}
                 borderColor={colourTheme.colors.Sliver}
                 borderWidth={1}
+                w="100%"
             >
                 <GridItem alignSelf="center" maxW={200}>
                     <AspectRatio width="100%" ratio={1}>

--- a/src/components/admin/ProgramViewInfoCard.tsx
+++ b/src/components/admin/ProgramViewInfoCard.tsx
@@ -78,6 +78,7 @@ export const ProgramViewInfoCard: React.FC<ProgramViewInfoCard> = ({ cardInfo, r
                 minH={165}
                 borderColor={colourTheme.colors.gray}
                 borderWidth={1}
+                w="100%"
             >
                 <GridItem alignSelf="center" colSpan={2} h="100%">
                     <AspectRatio ratio={2} h="inherit">


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Program/Class Card with little text too short, should take up full width in admin details page](https://www.notion.so/uwblueprintexecs/Program-Class-Card-with-little-text-too-short-should-take-up-full-width-in-admin-details-page-a12d5d4386564291958b68b37531cef8)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- use width=100% where it makes sense for info cards

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Create new program/class with 1/2 words. Viewing them in browse page, they should expand full width regardless of their content.

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
