### PR TITLE
fix(internal/api): filter ended classes upcoming

### DIFF
--- a/services/database/class.ts
+++ b/services/database/class.ts
@@ -80,6 +80,9 @@ async function getWeeklySortedClasses() {
     const classes = await prisma.class.findMany({
         where: {
             isArchived: false,
+            endDate: {
+                gt: new Date(new Date().toUTCString()),
+            },
         },
         include: {
             program: { include: { programTranslation: true } },


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Filter Ended Class for Internal Pages](https://www.notion.so/uwblueprintexecs/Filter-Ended-Class-for-Internal-Pages-a706f2aada4444978f5ff7475d03900b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- In the DB call for weekly upcoming classes, we filter by endDate greater than current date only

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Dashboard - ended classes should not appear
2. Upcoming class page - ended classes should not appear

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
