### PR TITLE
add prod terraform

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -103,7 +103,6 @@ jobs:
                 working-directory: ./terraform/environments
         env:
             TF_VAR_zoom_class_link_value: ${{ secrets.ZOOM_CLASS_LINK_VALUE }}
-            TF_VAR_lambda_secret_key_name: ${{ secrets.LAMBDA_SECRET_KEY_NAME }}
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -72,7 +72,6 @@ jobs:
                 working-directory: ./terraform/environments
         env:
             TF_VAR_zoom_class_link_value: ${{ secrets.ZOOM_CLASS_LINK_VALUE }}
-            TF_VAR_lambda_secret_key_name: ${{ secrets.LAMBDA_SECRET_KEY_NAME }}
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/terraform/environments/production/.terraform.lock.hcl
+++ b/terraform/environments/production/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.69.0"
+  hashes = [
+    "h1:1ud3VckbhSQ250tv58JCM9i1HKP05eijG4PEnU5PH7s=",
+    "zh:0cedd84ba908ba7190052b16cd7f70c41b0e2c2e914e54eecf2e3dae193f47fa",
+    "zh:14b89bac6412e20d415fe67d5f2eaa1414d9bbf75a5bd8fc963f6ab8e3b8b1a0",
+    "zh:159131129edab7ea118dee7d6daf1bfe4615f200a2d5120deb8369cbd2c4b598",
+    "zh:32a3a35964c9becb167180df905f34eb0cae7c30e00452527a0e600ee95c033f",
+    "zh:5330374066ca27d9a00ca667c81183c1dbfa0fcfdd5c1797a6185b76bc7c13bc",
+    "zh:78b75c45b7c660efaf89428ca988a77a4f55eba359f95ed7a54efe87fad1ab8b",
+    "zh:81f723c3f33dc0761ed12b025c1f411fe22f2c6a97e22f4adeb10f7668a5df8f",
+    "zh:98053adb091233fea8c1a82768dfce994e8407e2cb948d28ff88865d2d9a4dcd",
+    "zh:a52866826b51c0b4cb6b970cb3328542846e108c8f4d24c090d7ca0ffa341e44",
+    "zh:a9923cbdf30e9b66f889fef22e1f4b657d9ac1a48812f476ef841405a3c11525",
+    "zh:c079f98be9b8456e6eae6c07c5dcb84ecbcbb70b2f361f1c6f9c3ba90366d905",
+  ]
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -6,17 +6,17 @@ terraform {
   }
   # not possible to have this dynamic or populated through variables 
   backend "s3" {
-    bucket         = "sdc-prod-terraform-state"
+    bucket         = "sdc-app-terraform-state"
     key            = "terraform-state/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "sdc-prod-terraform-state-lock"
+    region         = "us-west-2"
+    dynamodb_table = "sdc-app-terraform-state-lock"
     encrypt        = true
   }
 }
 
 # configures the required provider
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "iam" {
@@ -29,11 +29,10 @@ module "s3" {
   allowed_origins = [var.sdc_domain, var.sdc_pr_domain]
 
   # uploads bucket 
-  s3_uploads_bucket_name  = var.s3_uploads_bucket_name
-  criminal_check_folder   = var.criminal_check_folder
-  income_proof_folder     = var.income_proof_folder
-  curriculum_plans_folder = var.curriculum_plans_folder
-  other_folder            = var.other_folder
+  s3_uploads_bucket_name = var.s3_uploads_bucket_name
+  criminal_check_folder  = var.criminal_check_folder
+  income_proof_folder    = var.income_proof_folder
+  other_folder           = var.other_folder
 
   # images bucket
   s3_images_bucket_name = var.s3_images_bucket_name

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -73,6 +73,6 @@ module "cronMailing_eventbridge" {
   source              = "../../modules/eventbridge"
   rule_name           = var.cronMailing_rule_name
   schedule_expression = var.cronMailing_schedule_expression
-  target_arn          = module.cronMailing.lamba_function_arn
-  target_id           = module.cronMailing.lamba_function_name
+  target_arn          = module.cronMailing.lambda_function_arn
+  target_id           = module.cronMailing.lambda_function_name
 }

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -26,7 +26,7 @@ module "iam" {
 
 module "s3" {
   source          = "../../modules/s3"
-  allowed_origins = [var.sdc_domain, var.sdc_pr_domain]
+  allowed_origins = [var.sdc_domain]
 
   # uploads bucket 
   s3_uploads_bucket_name = var.s3_uploads_bucket_name

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  # not possible to have this dynamic or populated through variables 
+  backend "s3" {
+    bucket         = "sdc-prod-terraform-state"
+    key            = "terraform-state/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "sdc-prod-terraform-state-lock"
+    encrypt        = true
+  }
+}
+
+# configures the required provider
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "iam" {
+  source                             = "../../modules/iam"
+  cloudwatch_lambda_logs_policy_name = var.cloudwatch_lambda_logs_policy_name
+}
+
+module "s3" {
+  source          = "../../modules/s3"
+  allowed_origins = [var.sdc_domain, var.sdc_pr_domain]
+
+  # uploads bucket 
+  s3_uploads_bucket_name  = var.s3_uploads_bucket_name
+  criminal_check_folder   = var.criminal_check_folder
+  income_proof_folder     = var.income_proof_folder
+  curriculum_plans_folder = var.curriculum_plans_folder
+  other_folder            = var.other_folder
+
+  # images bucket
+  s3_images_bucket_name = var.s3_images_bucket_name
+}
+
+module "parameter_store" {
+  source = "../../modules/parameter_store"
+
+  # Parameter store (ssm) inputs
+  # zoom link
+  zoom_class_link = {
+    description = var.zoom_class_link_description
+    name        = var.zoom_class_link_name
+    value       = var.zoom_class_link_value
+    type        = var.zoom_class_link_type
+  }
+
+  # lambda secret 
+  lambda_secret_key_name = var.lambda_secret_key_name
+}
+
+# Lambda functions, could encapsulate in another module for all lambda functions 
+module "cronMailing" {
+  source = "../../modules/lambda" # essentially wraps around a lambda 
+  # didn't put in variables since I thought it was redudant if the module is named the function
+  # could change though
+  function_name                     = "cronMailing"
+  runtime                           = var.lambda_runtime
+  cloudwatch_lambda_logs_policy_arn = module.iam.cloudwatch_lambda_logs_policy_arn
+  environment_variables = {
+    API_ENDPOINT      = var.api_endpoint
+    LAMBDA_SECRET_KEY = module.parameter_store.lambda_secret_key
+  }
+}
+
+# cron job for lambda cronMailing
+module "cronMailing_eventbridge" {
+  source              = "../../modules/eventbridge"
+  rule_name           = var.cronMailing_rule_name
+  schedule_expression = var.cronMailing_schedule_expression
+  target_arn          = module.cronMailing.lamba_function_arn
+  target_id           = module.cronMailing.lamba_function_name
+}

--- a/terraform/environments/production/remote_state/.terraform.lock.hcl
+++ b/terraform/environments/production/remote_state/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.69.0"
+  hashes = [
+    "h1:1ud3VckbhSQ250tv58JCM9i1HKP05eijG4PEnU5PH7s=",
+    "zh:0cedd84ba908ba7190052b16cd7f70c41b0e2c2e914e54eecf2e3dae193f47fa",
+    "zh:14b89bac6412e20d415fe67d5f2eaa1414d9bbf75a5bd8fc963f6ab8e3b8b1a0",
+    "zh:159131129edab7ea118dee7d6daf1bfe4615f200a2d5120deb8369cbd2c4b598",
+    "zh:32a3a35964c9becb167180df905f34eb0cae7c30e00452527a0e600ee95c033f",
+    "zh:5330374066ca27d9a00ca667c81183c1dbfa0fcfdd5c1797a6185b76bc7c13bc",
+    "zh:78b75c45b7c660efaf89428ca988a77a4f55eba359f95ed7a54efe87fad1ab8b",
+    "zh:81f723c3f33dc0761ed12b025c1f411fe22f2c6a97e22f4adeb10f7668a5df8f",
+    "zh:98053adb091233fea8c1a82768dfce994e8407e2cb948d28ff88865d2d9a4dcd",
+    "zh:a52866826b51c0b4cb6b970cb3328542846e108c8f4d24c090d7ca0ffa341e44",
+    "zh:a9923cbdf30e9b66f889fef22e1f4b657d9ac1a48812f476ef841405a3c11525",
+    "zh:c079f98be9b8456e6eae6c07c5dcb84ecbcbb70b2f361f1c6f9c3ba90366d905",
+  ]
+}

--- a/terraform/environments/production/remote_state/main.tf
+++ b/terraform/environments/production/remote_state/main.tf
@@ -7,12 +7,12 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 # "State store for terraform with S3"
 resource "aws_s3_bucket" "sdc_state_terraform" {
-  bucket = "sdc-prod-terraform-state"
+  bucket = "sdc-app-terraform-state"
   # acl?
   versioning {
     enabled = true
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "sdc_state_terraform" {
 
 # State locks for terraform with dynamo
 resource "aws_dynamodb_table" "sdc_terraform_state_lock" {
-  name           = "sdc-prod-terraform-state-lock"
+  name           = "sdc-app-terraform-state-lock"
   read_capacity  = 1
   write_capacity = 1
   # dynamo will be keyed + hashed on LockID which I think is populated by Terraform

--- a/terraform/environments/production/remote_state/main.tf
+++ b/terraform/environments/production/remote_state/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# "State store for terraform with S3"
+resource "aws_s3_bucket" "sdc_state_terraform" {
+  bucket = "sdc-prod-terraform-state"
+  # acl?
+  versioning {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    name = "Terraform Remote S3 State Store"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+# State locks for terraform with dynamo
+resource "aws_dynamodb_table" "sdc_terraform_state_lock" {
+  name           = "sdc-prod-terraform-state-lock"
+  read_capacity  = 1
+  write_capacity = 1
+  # dynamo will be keyed + hashed on LockID which I think is populated by Terraform
+  hash_key     = "LockID"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    name = "Terraform Remote Dynamo State Lock"
+  }
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -28,13 +28,13 @@ variable "cloudwatch_lambda_logs_policy_name" {
 
 variable "s3_images_bucket_name" {
   description = "Name of the document uploads s3 bucket"
-  default     = "sdc-prod-public-images"
+  default     = "sdc-app-public-images"
   type        = string
 }
 
 variable "s3_uploads_bucket_name" {
   description = "Name of the document uploads s3 bucket"
-  default     = "sdc-prod-uploads"
+  default     = "sdc-app-uploads"
   type        = string
 }
 
@@ -47,12 +47,6 @@ variable "criminal_check_folder" {
 variable "income_proof_folder" {
   description = "Name of the income proof folder"
   default     = "income-proof"
-  type        = string
-}
-
-variable "curriculum_plans_folder" {
-  description = "Name of the curriculum plans folder"
-  default     = "curriculum-plans"
   type        = string
 }
 

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -8,12 +8,6 @@ variable "sdc_domain" {
   type        = string
 }
 
-variable "sdc_pr_domain" {
-  description = "domain of pr deploys"
-  default     = "https://social-diversity-for-children-pr-*.up.railway.app"
-  type        = string
-}
-
 # should add variable condition checks to limit configuration discrepencies
 # ------------------------------------------------------------------
 # IAM

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -107,5 +107,6 @@ variable "api_endpoint" {
 
 variable "lambda_secret_key_name" {
   description = "Name of lambda secret key"
+  default     = "LAMBDA_SECRET_KEY"
   type        = string
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -1,0 +1,123 @@
+# NOTE
+# Variables without a default are inputted secretly. Generally only define variables with a default for non-secrets
+# ------------------------------------------------------------------
+# app
+variable "sdc_domain" {
+  description = "full domain name"
+  default     = "https://app.socialdiversity.org"
+  type        = string
+}
+
+variable "sdc_pr_domain" {
+  description = "domain of pr deploys"
+  default     = "https://social-diversity-for-children-pr-*.up.railway.app"
+  type        = string
+}
+
+# should add variable condition checks to limit configuration discrepencies
+# ------------------------------------------------------------------
+# IAM
+variable "cloudwatch_lambda_logs_policy_name" {
+  description = "Name of cloudwatch lambda logs policy"
+  default     = "cloudwatch-lambda-logs-policy"
+  type        = string
+}
+
+# ------------------------------------------------------------------
+# s3
+
+variable "s3_images_bucket_name" {
+  description = "Name of the document uploads s3 bucket"
+  default     = "sdc-prod-public-images"
+  type        = string
+}
+
+variable "s3_uploads_bucket_name" {
+  description = "Name of the document uploads s3 bucket"
+  default     = "sdc-prod-uploads"
+  type        = string
+}
+
+variable "criminal_check_folder" {
+  description = "Name of the criminal check folder"
+  default     = "criminal-check"
+  type        = string
+}
+
+variable "income_proof_folder" {
+  description = "Name of the income proof folder"
+  default     = "income-proof"
+  type        = string
+}
+
+variable "curriculum_plans_folder" {
+  description = "Name of the curriculum plans folder"
+  default     = "curriculum-plans"
+  type        = string
+}
+
+variable "other_folder" {
+  description = "Name of the other folder (folder where files are uploaded when type isn't specified)"
+  default     = "other"
+  type        = string
+}
+
+# ------------------------------------------------------------------
+# Parameter Store (SSM)
+# zoom-class-link
+variable "zoom_class_link_description" {
+  description = "Description of zoom class link parameter"
+  default     = "Link used to access virtual classes hosted over Zoom"
+  type        = string
+}
+
+variable "zoom_class_link_name" {
+  description = "Zoom class link parameter name"
+  default     = "zoom-class-link"
+  type        = string
+}
+
+variable "zoom_class_link_value" {
+  description = "Zoom class link parameter value"
+  type        = string
+}
+
+variable "zoom_class_link_type" {
+  description = "Zoom class link type"
+  default     = "String"
+  type        = string
+}
+
+# ------------------------------------------------------------------
+# lambda
+variable "lambda_runtime" {
+  description = "Runtime of lambda function. botocore.vendored.requests is depreciated and gone in python 3.8. Unless we use a special layer from amazon"
+  default     = "python3.8"
+  type        = string
+}
+
+variable "cronMailing_rule_name" {
+  description = "Name of cronMailing eventbridge rule"
+  default     = "hourly-cron-mailing"
+  type        = string
+}
+
+variable "cronMailing_schedule_expression" {
+  description = "CRON or Rate expression for cronMailing job"
+  default     = "cron(0 * ? * * *)" # hourly cron expression
+  type        = string
+}
+
+# ------------------------------------------------------------------
+# environment variables
+
+variable "api_endpoint" {
+  description = "Domain api endpoint"
+  default     = "https://app.socialdiversity.org/api"
+  type        = string
+}
+
+variable "lambda_secret_key_name" {
+  description = "Name of lambda secret key"
+  type        = string
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -73,6 +73,6 @@ module "cronMailing_eventbridge" {
   source              = "../../modules/eventbridge"
   rule_name           = var.cronMailing_rule_name
   schedule_expression = var.cronMailing_schedule_expression
-  target_arn          = module.cronMailing.lamba_function_arn
-  target_id           = module.cronMailing.lamba_function_name
+  target_arn          = module.cronMailing.lambda_function_arn
+  target_id           = module.cronMailing.lambda_function_name
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -29,11 +29,10 @@ module "s3" {
   allowed_origins = ["http://localhost:3000", var.sdc_domain, var.sdc_pr_domain]
 
   # uploads bucket 
-  s3_uploads_bucket_name  = var.s3_uploads_bucket_name
-  criminal_check_folder   = var.criminal_check_folder
-  income_proof_folder     = var.income_proof_folder
-  curriculum_plans_folder = var.curriculum_plans_folder
-  other_folder            = var.other_folder
+  s3_uploads_bucket_name = var.s3_uploads_bucket_name
+  criminal_check_folder  = var.criminal_check_folder
+  income_proof_folder    = var.income_proof_folder
+  other_folder           = var.other_folder
 
   # images bucket
   s3_images_bucket_name = var.s3_images_bucket_name

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -113,5 +113,6 @@ variable "api_endpoint" {
 
 variable "lambda_secret_key_name" {
   description = "Name of lambda secret key"
+  default     = "LAMBDA_SECRET_KEY"
   type        = string
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -50,12 +50,6 @@ variable "income_proof_folder" {
   type        = string
 }
 
-variable "curriculum_plans_folder" {
-  description = "Name of the curriculum plans folder"
-  default     = "curriculum-plans"
-  type        = string
-}
-
 variable "other_folder" {
   description = "Name of the other folder (folder where files are uploaded when type isn't specified)"
   default     = "other"

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -1,9 +1,9 @@
-output "lamba_function_arn" {
+output "lambda_function_arn" {
   description = "The ARN of the Lambda Function"
   value       = aws_lambda_function.this.arn
 }
 
-output "lamba_function_name" {
+output "lambda_function_name" {
   description = "The name of the Lambda Function"
   value       = aws_lambda_function.this.function_name
 }

--- a/terraform/modules/s3/inputs.tf
+++ b/terraform/modules/s3/inputs.tf
@@ -29,12 +29,6 @@ variable "income_proof_folder" {
   type        = string
 }
 
-variable "curriculum_plans_folder" {
-  description = "Name of the curriculum plans folder"
-  default     = "curriculum-plans"
-  type        = string
-}
-
 variable "other_folder" {
   description = "Name of the other folder (folder where files are uploaded when type isn't specified)"
   default     = "other"

--- a/terraform/modules/s3/s3.tf
+++ b/terraform/modules/s3/s3.tf
@@ -102,17 +102,6 @@ resource "aws_s3_bucket_object" "income_proof_folder" {
   }
 }
 
-# curriculum_plans_folder
-resource "aws_s3_bucket_object" "curriculum_plans_folder" {
-  bucket       = aws_s3_bucket.s3_uploads.id
-  acl          = "private"
-  key          = "${var.curriculum_plans_folder}/"
-  content_type = "application/x-directory"
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 # other folder
 resource "aws_s3_bucket_object" "other_folder" {
   bucket       = aws_s3_bucket.s3_uploads.id


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/6dd603d3687743ce8d09d6298dc99748?v=7332b6570bcc4b48b5cd73fa2719bec8&p=2c7608b53c6c4781b45b627f6092e33f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Add production terraform. Same as staging. Currently the s3 bucket names have prod embedded in the name whereas in staging it does. I.e. prod: `sdc-prod-uploads` vs staging: `sdc-uploads`. This is something we should look into fixing.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

-

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
