### PR TITLE
fix(api): update document resets approved

### DIFF
--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -89,7 +89,7 @@ CREATE TABLE classes (
 CREATE TABLE parents (
   id SERIAL PRIMARY KEY NOT NULL,
   phone_number VARCHAR(50) NOT NULL,
-  is_low_income BOOLEAN DEFAULT false,
+  is_low_income BOOLEAN,
   preferred_language locales NOT NULL,
   proof_of_income_link TEXT,
   proof_of_income_submitted_at TIMESTAMPTZ,

--- a/services/database/user.ts
+++ b/services/database/user.ts
@@ -392,6 +392,7 @@ async function updateVolunteerCriminalCheckLink(email: string, link: string, dat
                 update: {
                     criminalRecordCheckLink: link,
                     criminalCheckSubmittedAt: date,
+                    criminalCheckApproved: null,
                 },
             },
         },
@@ -441,6 +442,7 @@ async function updateParentProofOfIncomeLink(email: string, link: string, date: 
                 update: {
                     proofOfIncomeLink: link,
                     proofOfIncomeSubmittedAt: date,
+                    isLowIncome: null,
                 },
             },
         },


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[BUG: when submitting new criminal check or income proof, switch current approval status to false as precaution ](https://www.notion.so/uwblueprintexecs/BUG-when-submitting-new-criminal-check-or-income-proof-switch-current-approval-status-to-false-as--b1e7b472f4bc485799ad9cfc7cb717b0)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- When updating bgc or poi of user, also reset the approved status to null
- fixed default value of is low income to null, which is pending state

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. As volunteer, submit bgc, approve it in the DB, and submit another doc. the second doc should be pending
2. same as step one but for parent poi

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->


### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
