### PR TITLE
fix(waitlist): mobile with translations

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -35,6 +35,7 @@
         "upcomingClasses": "Upcoming classes",
         "waitlistedClasses": "Waitlisted classes",
         "waitlistedInfo": "An email will be sent to you when a spot opens",
+        "waitlistCancel": "Remove from Waitlist",
         "emptyWaitlist": "Currently you are not waitlisted in any classes. Any classes you waitlist for will show up here!",
         "emptyClass": "Currently you have not registered in any classes. Any classes you registered for will show up here!"
     },

--- a/src/components/ClassInfoCard.tsx
+++ b/src/components/ClassInfoCard.tsx
@@ -111,8 +111,8 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
                                     borderColor={colourTheme.colors.Blue}
                                     color={colourTheme.colors.Blue}
                                     variant="outline"
-                                    mr="3"
-                                    width="30%"
+                                    mx={3}
+                                    px={8}
                                 >
                                     {t("program.learnMore")}
                                 </Button>

--- a/src/components/WaitlistCard.tsx
+++ b/src/components/WaitlistCard.tsx
@@ -1,27 +1,15 @@
-import React from "react";
-import {
-    Box,
-    AspectRatio,
-    Image,
-    Heading,
-    Flex,
-    Grid,
-    Text,
-    GridItem,
-    Spacer,
-    VStack,
-    Button,
-} from "@chakra-ui/react";
-import { weekdayToString } from "@utils/enum/weekday";
-import convertToShortTimeRange from "@utils/convertToShortTimeRange";
+import { AspectRatio, Box, Grid, GridItem, Heading, Image, Text, VStack } from "@chakra-ui/react";
 import { WaitlistCardInfo } from "@models/Enroll";
-import colourTheme from "@styles/colours";
-import convertToShortDateRange from "@utils/convertToShortDateRange";
-import { deleteWaitlistRegistration } from "@utils/deleteWaitlistRegistration";
-import { useRouter } from "next/router";
-import { useTranslation } from "next-i18next";
 import { locale } from "@prisma/client";
+import convertToShortDateRange from "@utils/convertToShortDateRange";
+import convertToShortTimeRange from "@utils/convertToShortTimeRange";
+import { deleteWaitlistRegistration } from "@utils/deleteWaitlistRegistration";
+import { weekdayToString } from "@utils/enum/weekday";
 import { totalMinutes } from "@utils/time/convert";
+import { useTranslation } from "next-i18next";
+import { useRouter } from "next/router";
+import React from "react";
+import { PrimaryButton } from "./SDCButton";
 
 type WaitlistCardProps = {
     waitlistInfo: WaitlistCardInfo;
@@ -47,77 +35,48 @@ export const WaitlistCard: React.FC<WaitlistCardProps> = ({ waitlistInfo }) => {
                     />
                 </AspectRatio>
             </GridItem>
-            <GridItem colSpan={3}>
+            <GridItem colSpan={3} py={3}>
                 <VStack align="left" justify="center" height="100%">
-                    <Flex mr="3" direction="column">
-                        <Box>
-                            <Heading size="md" pb={4} pr={2}>
-                                {waitlistInfo.program.name} ({waitlistInfo.class.name})
-                            </Heading>
-                            <Box as="span" color="gray.600" fontSize="sm">
-                                <Text>
-                                    {t("time.weekday_many", {
-                                        day: weekdayToString(
-                                            waitlistInfo.class.weekday,
-                                            router.locale as locale,
-                                        ),
-                                    })}{" "}
-                                    {convertToShortTimeRange(
-                                        totalMinutes(waitlistInfo.class.startDate),
-                                        waitlistInfo.class.durationMinutes,
-                                    )}
-                                    {" with " +
-                                        t("program.teacherName", {
-                                            name: waitlistInfo.class.teacherName,
-                                        })}
-                                </Text>
-                                <Text>
-                                    {t("time.range", {
-                                        ...convertToShortDateRange(
-                                            waitlistInfo.class.startDate,
-                                            waitlistInfo.class.endDate,
-                                            router.locale as locale,
-                                        ),
+                    <Box pb={2}>
+                        <Heading size="md" pb={4} pr={2}>
+                            {waitlistInfo.program.name} ({waitlistInfo.class.name})
+                        </Heading>
+                        <Box as="span" color="gray.600" fontSize="sm">
+                            <Text>
+                                {t("time.weekday_many", {
+                                    day: weekdayToString(
+                                        waitlistInfo.class.weekday,
+                                        router.locale as locale,
+                                    ),
+                                })}{" "}
+                                {convertToShortTimeRange(
+                                    totalMinutes(waitlistInfo.class.startDate),
+                                    waitlistInfo.class.durationMinutes,
+                                )}
+                                {" with " +
+                                    t("program.teacherName", {
+                                        name: waitlistInfo.class.teacherName,
                                     })}
-                                </Text>
-                            </Box>
+                            </Text>
+                            <Text>
+                                {t("time.range", {
+                                    ...convertToShortDateRange(
+                                        waitlistInfo.class.startDate,
+                                        waitlistInfo.class.endDate,
+                                        router.locale as locale,
+                                    ),
+                                })}
+                            </Text>
                         </Box>
-                        <Spacer />
-                        <Flex alignItems={"baseline"}>
-                            <Button
-                                bg={colourTheme.colors.Blue}
-                                color={"white"}
-                                mx={"auto"}
-                                my={2}
-                                mr={5}
-                                borderRadius="6px"
-                                fontWeight={"normal"}
-                                _hover={{
-                                    textDecoration: "none",
-                                    bg: colourTheme.colors.LightBlue,
-                                }}
-                                _active={{
-                                    bg: "lightgrey",
-                                    outlineColor: "grey",
-                                    border: "grey",
-                                    boxShadow: "lightgrey",
-                                }}
-                                _focus={{
-                                    outlineColor: "grey",
-                                    border: "grey",
-                                    boxShadow: "lightgrey",
-                                }}
-                                onClick={() =>
-                                    deleteWaitlistRegistration(
-                                        waitlistInfo.parent,
-                                        waitlistInfo.classId,
-                                    )
-                                }
-                            >
-                                {t("class.waitlistCancel")}
-                            </Button>
-                        </Flex>
-                    </Flex>
+                    </Box>
+                    <PrimaryButton
+                        onClick={() =>
+                            deleteWaitlistRegistration(waitlistInfo.parent, waitlistInfo.classId)
+                        }
+                        width={"fit-content"}
+                    >
+                        {t("class.waitlistCancel")}
+                    </PrimaryButton>
                 </VStack>
             </GridItem>
         </Grid>

--- a/src/components/WaitlistCard.tsx
+++ b/src/components/WaitlistCard.tsx
@@ -49,7 +49,7 @@ export const WaitlistCard: React.FC<WaitlistCardProps> = ({ waitlistInfo }) => {
             </GridItem>
             <GridItem colSpan={3}>
                 <VStack align="left" justify="center" height="100%">
-                    <Flex mr="3">
+                    <Flex mr="3" direction="column">
                         <Box>
                             <Heading size="md" pb={4} pr={2}>
                                 {waitlistInfo.program.name} ({waitlistInfo.class.name})
@@ -114,7 +114,7 @@ export const WaitlistCard: React.FC<WaitlistCardProps> = ({ waitlistInfo }) => {
                                     )
                                 }
                             >
-                                Remove from Waitlist
+                                {t("class.waitlistCancel")}
                             </Button>
                         </Flex>
                     </Flex>


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Mobile Waitlist Class Buttons Should be Responsive](https://www.notion.so/uwblueprintexecs/Mobile-Waitlist-Class-Buttons-Should-be-Responsive-00b01578ceea4336a8833e19c65b7946)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

https://user-images.githubusercontent.com/44826218/146693924-4ceab63e-62da-4b89-95c7-b9b1e597d1a4.mp4

- Flex should be column direction when appropriate
- Integrate missing translation for remove waitlist

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Login as parent and add waitlist
2. Test waitlist on mobile and on desktop. Expected: the button should no longer cut off

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
