### PR TITLE
refactoring footer for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developers: Jason Huang, Soha Khan, Cindy Wang, Brandon Wong, Victor Yun, Mahad 
 7. Service: [Amazon SES](https://aws.amazon.com/ses/) for email service
 8. Service: [Amazon Lambda](https://aws.amazon.com/lambda/) and [Amazon Cloudwatch](https://aws.amazon.com/cloudwatch/) for notification mailing
 9. Service: [Amazon Systems Manager](https://aws.amazon.com/systems-manager/) for Storing one-time dynamic links
-10. Service: [Stripe](https://stripe.com/) for Class payment and product/coupon management 
+10. Service: [Stripe](https://stripe.com/) for Class payment and product/coupon management
 11. Service: [Railway](https://docs.railway.app/) for deployment and database hosting
 12. Service: [Heroku](https://www.heroku.com/postgres) for PostgreSQL DB hosting
 13. [Unstated Next](https://github.com/jamiebuilds/unstated-next) for state management

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,25 +15,16 @@ const SocialMediaLinks = [
     },
 ];
 
-export const DEFAULT_FOOTER_HEIGHT = 364;
-
 export const Footer: React.FC<FooterProps> = (props) => {
     return (
-        <Box
-            bg={"#0C53A0"}
-            color={"white"}
-            px={{ base: 4, lg: 48 }}
-            position={"absolute"}
-            bottom={0}
-            width={"100%"}
-        >
+        <Box bg={"#0C53A0"} color={"white"} px={{ base: 4, lg: 48 }} width={"100%"}>
             <Container
                 as={Stack}
                 maxW={"100%"}
                 py={6}
                 spacing={4}
                 justify={"center"}
-                minHeight={props.height || DEFAULT_FOOTER_HEIGHT}
+                minHeight={props.height}
             >
                 <Stack>
                     <Flex direction={{ base: "column", md: "row" }}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,16 +15,28 @@ const SocialMediaLinks = [
     },
 ];
 
+export const DEFAULT_FOOTER_HEIGHT = 425;
+
 export const Footer: React.FC<FooterProps> = (props) => {
     return (
-        <Box bg={"#0C53A0"} color={"white"} px={{ base: 4, lg: 48 }} width={"100%"}>
+        <Box
+            as="footer"
+            role="contentinfo"
+            mx="auto"
+            bg={"#0C53A0"}
+            color={"white"}
+            px={{ base: 4, lg: 48 }}
+            position={"absolute"}
+            bottom={0}
+            width={"100%"}
+        >
             <Container
                 as={Stack}
                 maxW={"100%"}
                 py={6}
                 spacing={4}
                 justify={"center"}
-                minHeight={props.height}
+                height={props.height || DEFAULT_FOOTER_HEIGHT}
             >
                 <Stack>
                     <Flex direction={{ base: "column", md: "row" }}>

--- a/src/components/SDCWrapper.tsx
+++ b/src/components/SDCWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Navbar } from "./Navbar";
-import { Footer, DEFAULT_FOOTER_HEIGHT } from "./Footer";
+import { Footer } from "./Footer";
 import { Box } from "@chakra-ui/react";
 import { Session } from "next-auth";
 
@@ -12,9 +12,7 @@ const SDCWrapper: React.FC<SDCWrapperProps> = (props): JSX.Element => {
     return (
         <Box minHeight={"100vh"} position={"relative"}>
             <Navbar session={props.session} />
-            <Box pb={DEFAULT_FOOTER_HEIGHT} px={{ base: 6, md: 12, lg: 48 }}>
-                {props.children}
-            </Box>
+            <Box px={{ base: 6, md: 12, lg: 48 }}>{props.children}</Box>
             <Footer />
         </Box>
     );

--- a/src/components/SDCWrapper.tsx
+++ b/src/components/SDCWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Navbar } from "./Navbar";
-import { Footer } from "./Footer";
+import { DEFAULT_FOOTER_HEIGHT, Footer } from "./Footer";
 import { Box } from "@chakra-ui/react";
 import { Session } from "next-auth";
 
@@ -12,7 +12,9 @@ const SDCWrapper: React.FC<SDCWrapperProps> = (props): JSX.Element => {
     return (
         <Box minHeight={"100vh"} position={"relative"}>
             <Navbar session={props.session} />
-            <Box px={{ base: 6, md: 12, lg: 48 }}>{props.children}</Box>
+            <Box pb={DEFAULT_FOOTER_HEIGHT} px={{ base: 6, md: 12, lg: 48 }}>
+                {props.children}
+            </Box>
             <Footer />
         </Box>
     );


### PR DESCRIPTION
### Notion ticket link


[Mobile Footer Is too big, blocks buttons](https://www.notion.so/uwblueprintexecs/Mobile-Footer-Is-too-bug-blocks-buttons-78ed1e8666e946f585e62d424851f07a)

### Implementation description

- Removed "position: absolute" property from footer and MIN_HEIGHT condition for footer height

### Steps to test

1. Open project in chrome and change view to a mobile device
2. Navigate through the following flows and ensure that footer is not obstructive:
       a) Login
       b) Create account
       c) Register for class
       d) View classes

### What should reviewers focus on?

- Ensure that the footer is not obstructing any other aspects of the UI

### Checklist

-   [x] My PR name is descriptive and in imperative tense
-   [x] I have run the linter
-   [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
