### PR TITLE
feat(myaccounts): add states for denied docs

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -54,8 +54,10 @@
         "dateSubmitted": "Date submitted: {{date}}",
         "poi_approved": "Your income statement has been approved. Please be on the lookout for an email from SDC with the discount for future registrations.",
         "poi_pending": "Your income statement is under review.",
+        "poi_declined": "You have been declined for low income discounts. Please contact SDC if you think this is a mistake or submit a new income statement.",
         "bgc_approved": "Your criminal record check has been approved.",
         "bgc_pending": "Your criminal record check is under review.",
+        "bgc_declined": "Your criminal record check has been declined. Please contact SDC if you think this is a mistake or submit a new criminal record check.",
         "logOut": "Log out"
     },
     "upload": {

--- a/src/components/myAccounts/CriminalCheck.tsx
+++ b/src/components/myAccounts/CriminalCheck.tsx
@@ -34,13 +34,20 @@ export const CriminalCheck: React.FC<CriminalCheckProps> = ({
     } else if (link == null) {
         description = t("bgc.missing");
         icon = <InfoIcon />;
-    } else {
+    } else if (approved === null) {
         status = "pending";
         description = t("account.bgc", {
             ns: "common",
             context: status,
         });
         icon = <PendingIcon />;
+    } else {
+        status = "declined";
+        description = t("account.bgc", {
+            ns: "common",
+            context: status,
+        });
+        icon = <InfoIcon />;
     }
 
     return (

--- a/src/components/myAccounts/ParticipantInformation.tsx
+++ b/src/components/myAccounts/ParticipantInformation.tsx
@@ -213,7 +213,6 @@ export const ParticipantInfo: React.FC<ParticipantPageProps> = ({ props }): JSX.
                     placeholder="5"
                     required={false}
                     edit={props.edit}
-                    number={true}
                 ></TextField>
                 <br />
                 <br />

--- a/src/components/myAccounts/ProofOfIncome.tsx
+++ b/src/components/myAccounts/ProofOfIncome.tsx
@@ -34,13 +34,20 @@ export const ProofOfIncome: React.FC<ProofOfIncomeProps> = ({
     } else if (link == null) {
         description = t("poi.missing");
         icon = <InfoIcon />;
-    } else {
+    } else if (approved === null) {
         status = "pending";
         description = t("account.poi", {
             ns: "common",
             context: status,
         });
         icon = <PendingIcon />;
+    } else {
+        status = "declined";
+        description = t("account.poi", {
+            ns: "common",
+            context: status,
+        });
+        icon = <InfoIcon />;
     }
 
     return (


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[No criminal check denied flow for myaccount page](https://www.notion.so/uwblueprintexecs/No-criminal-check-denied-flow-for-myaccount-page-6598e06c51f74c8cbcc059418651bc92)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

Parent - Income Proof for Discount:

![poi_denied](https://user-images.githubusercontent.com/44826218/146867423-d9a8d9b8-f274-498b-94ac-474ccf25a5ab.png)

Volunteer - Criminal Check Approval Status

![bgc_denied](https://user-images.githubusercontent.com/44826218/146867426-65cd337c-f296-468a-9485-79ec03629df4.png)

- Consider state for null cases as pending and false as declined
- Fix bug introduced in #201 where grade is expected to be a required number

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Upload doc as volunteer, as admin, deny the doc, as parent, we should see the case pictured above
2. vice versa for parent

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
