### PR TITLE
fix(class-cards): add mobile responsive

### DIFF
--- a/src/components/ClassInfoCard.tsx
+++ b/src/components/ClassInfoCard.tsx
@@ -10,6 +10,7 @@ import {
     GridItem,
     Spacer,
     VStack,
+    useBreakpointValue,
 } from "@chakra-ui/react";
 import { weekdayToString } from "@utils/enum/weekday";
 import { ClassCardInfo } from "@models/Class";
@@ -44,6 +45,7 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
     const router = useRouter();
     const { t } = useTranslation("common");
     const { me } = useMe();
+    const isAgeBadgeBesideTitle = useBreakpointValue({ base: false, md: true });
 
     return (
         <Grid templateColumns="repeat(4, 1fr)" gap={6} onClick={onClick} cursor={"pointer"}>
@@ -64,7 +66,7 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
                             {cardInfo.name}
                         </Box>
                         <Spacer />
-                        {cardInfo.borderAge == null ? null : (
+                        {cardInfo.borderAge == null || !isAgeBadgeBesideTitle ? null : (
                             <AgeBadge
                                 isOff={!isEligible}
                                 isAgeMinimal={cardInfo.isAgeMinimal}
@@ -99,6 +101,15 @@ export const ClassInfoCard: React.FC<ClassInfoProps> = ({
                                       context: cardInfo.spaceAvailable !== 1 ? "plural" : "",
                                   })}
                         </Box>
+                        {cardInfo.borderAge != null && isAgeBadgeBesideTitle ? null : (
+                            <Box mt={3}>
+                                <AgeBadge
+                                    isOff={!isEligible}
+                                    isAgeMinimal={cardInfo.isAgeMinimal}
+                                    borderAge={cardInfo.borderAge}
+                                />
+                            </Box>
+                        )}
                     </Flex>
                     {isFull && (
                         <Box>

--- a/src/components/FormClass.tsx
+++ b/src/components/FormClass.tsx
@@ -10,6 +10,7 @@ import {
     GridItem,
     Spacer,
     VStack,
+    useBreakpointValue,
 } from "@chakra-ui/react";
 import { weekdayToString } from "@utils/enum/weekday";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
@@ -29,6 +30,8 @@ export const FormClassCard: React.FC<FormClassCardProps> = ({ classInfo }) => {
     const router = useRouter();
     const { t } = useTranslation();
 
+    const isAgeBadgeBesideTitle = useBreakpointValue({ base: false, md: true });
+
     return (
         <Grid border="1px solid #C5C5C5" templateColumns="repeat(4, 1fr)" gap={6}>
             <GridItem>
@@ -36,7 +39,7 @@ export const FormClassCard: React.FC<FormClassCardProps> = ({ classInfo }) => {
                     <Image src={classInfo.image} fit="cover" alt={classInfo.name} />
                 </AspectRatio>
             </GridItem>
-            <GridItem colSpan={3}>
+            <GridItem colSpan={3} py={3}>
                 <VStack align="left" justify="center" height="100%">
                     <Flex mr="3">
                         <Box>
@@ -71,14 +74,23 @@ export const FormClassCard: React.FC<FormClassCardProps> = ({ classInfo }) => {
                                     })}
                                 </Text>
                             </Box>
+                            {isAgeBadgeBesideTitle ? null : (
+                                <AgeBadge
+                                    borderAge={classInfo.borderAge}
+                                    isAgeMinimal={classInfo.isAgeMinimal}
+                                    mt={3}
+                                />
+                            )}
                         </Box>
                         <Spacer />
-                        <Flex alignItems={"baseline"}>
-                            <AgeBadge
-                                borderAge={classInfo.borderAge}
-                                isAgeMinimal={classInfo.isAgeMinimal}
-                            />
-                        </Flex>
+                        {!isAgeBadgeBesideTitle ? null : (
+                            <Flex alignItems={"baseline"}>
+                                <AgeBadge
+                                    borderAge={classInfo.borderAge}
+                                    isAgeMinimal={classInfo.isAgeMinimal}
+                                />
+                            </Flex>
+                        )}
                     </Flex>
                 </VStack>
             </GridItem>

--- a/src/components/VolunteeringCard.tsx
+++ b/src/components/VolunteeringCard.tsx
@@ -17,6 +17,7 @@ import {
     MenuItem,
     MenuList,
     Link,
+    useBreakpointValue,
 } from "@chakra-ui/react";
 import { weekdayToString } from "@utils/enum/weekday";
 import convertToShortTimeRange from "@utils/convertToShortTimeRange";
@@ -35,6 +36,7 @@ type VolunteeringCardProps = {
     volunteeringInfo: VolunteeringCardInfo;
 };
 
+// TODO: make sure that the card is responsive like enrollment card
 /**
  * VolunteeringCard is a single card representing an volunteer enrollment in a class
  * @param volunteeringInfo info of volunteering card
@@ -43,8 +45,39 @@ type VolunteeringCardProps = {
 export const VolunteeringCard: React.FC<VolunteeringCardProps> = ({ volunteeringInfo }) => {
     const router = useRouter();
     const { t } = useTranslation("common");
+    const isJoinBesideTitle = useBreakpointValue({ base: false, md: true });
 
     const { link } = useGetZoomLink();
+
+    const joinLink = (
+        <Link href={link} isExternal>
+            <Button
+                bg={colourTheme.colors.Blue}
+                color={"white"}
+                mx={"auto"}
+                my={2}
+                borderRadius="6px"
+                fontWeight={"normal"}
+                _hover={{
+                    textDecoration: "none",
+                    bg: colourTheme.colors.LightBlue,
+                }}
+                _active={{
+                    bg: "lightgrey",
+                    outlineColor: "grey",
+                    border: "grey",
+                    boxShadow: "lightgrey",
+                }}
+                _focus={{
+                    outlineColor: "grey",
+                    border: "grey",
+                    boxShadow: "lightgrey",
+                }}
+            >
+                {t("class.joinClass")}
+            </Button>
+        </Link>
+    );
 
     return (
         <Grid templateColumns="repeat(4, 1fr)" gap={6}>
@@ -57,7 +90,7 @@ export const VolunteeringCard: React.FC<VolunteeringCardProps> = ({ volunteering
                     />
                 </AspectRatio>
             </GridItem>
-            <GridItem colSpan={3}>
+            <GridItem colSpan={3} py={3}>
                 <VStack align="left" justify="center" height="100%">
                     <Flex mr="3">
                         <Box>
@@ -90,37 +123,12 @@ export const VolunteeringCard: React.FC<VolunteeringCardProps> = ({ volunteering
                                         ),
                                     })}
                                 </Text>
+                                {isJoinBesideTitle ? null : joinLink}
                             </Box>
                         </Box>
                         <Spacer />
                         <Flex alignItems={"baseline"}>
-                            <Link href={link} isExternal>
-                                <Button
-                                    bg={colourTheme.colors.Blue}
-                                    color={"white"}
-                                    mx={"auto"}
-                                    my={2}
-                                    borderRadius="6px"
-                                    fontWeight={"normal"}
-                                    _hover={{
-                                        textDecoration: "none",
-                                        bg: colourTheme.colors.LightBlue,
-                                    }}
-                                    _active={{
-                                        bg: "lightgrey",
-                                        outlineColor: "grey",
-                                        border: "grey",
-                                        boxShadow: "lightgrey",
-                                    }}
-                                    _focus={{
-                                        outlineColor: "grey",
-                                        border: "grey",
-                                        boxShadow: "lightgrey",
-                                    }}
-                                >
-                                    {t("class.joinClass")}
-                                </Button>
-                            </Link>
+                            {isJoinBesideTitle ? joinLink : null}
                             <Menu>
                                 <MenuButton
                                     ml={1}


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Need Class Cards to be Responsive in Volunteer Classes, Checkout, and Program details page](https://www.notion.so/uwblueprintexecs/Need-Class-Cards-to-be-Responsive-in-Volunteer-Classes-Checkout-and-Program-details-page-27a105d5f0ce4a6c869d47b00ad60ffe)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Volunteer class page: same change down as parent class page. Join button should column flex with text when appropriate
- checkout page: age badge flex
- program details: better age badge flex

For program details, the following change was made to consider for the length of the title:
Before:
![image](https://user-images.githubusercontent.com/44826218/147185730-0e935824-fb67-401a-b43f-ffc46398380e.png)
After:
![image](https://user-images.githubusercontent.com/44826218/147185742-9b20ba39-5d84-4f8a-8d71-84011f32f34e.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Affected pages with width ~400

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
