### PR TITLE
fix(signup): save upload file link via query param

### DIFF
--- a/models/User.ts
+++ b/models/User.ts
@@ -11,6 +11,7 @@ export type ParentInput = {
     isLowIncome?: boolean;
     preferredLanguage: locale;
     proofOfIncomeLink?: string;
+    proofOfIncomeSubmittedAt?: Date;
     heardFrom?: heardFrom[];
     heardFromOther?: string;
     createStudentInput?: CreateStudentInput;
@@ -23,6 +24,7 @@ export type VolunteerInput = {
     criminalRecordCheckLink?: string;
     criminalCheckApproved?: boolean;
     criminalCheckExpired?: boolean;
+    criminalCheckSubmittedAt?: Date;
     addressLine1: string;
     postalCode: string;
     cityName: string;

--- a/pages/document-upload.tsx
+++ b/pages/document-upload.tsx
@@ -4,6 +4,7 @@ import { CloseButton } from "@components/CloseButton";
 import DragAndDrop from "@components/DragAndDrop";
 import { ApprovedIcon } from "@components/icons";
 import Wrapper from "@components/SDCWrapper";
+import { pathWithQuery } from "@utils/request/query";
 import { GetServerSideProps } from "next"; // Get server side props
 import { Session } from "next-auth";
 import { getSession } from "next-auth/client";
@@ -30,6 +31,7 @@ export default function DocumentUpload({ session }: DocumentUploadProps): JSX.El
     // allows future support of multiple file uploads
     // if we really want to restrict to one document, remove the multiple from the input
     const [files, setFiles] = useState<File[]>([]);
+    const [fileName, setFileName] = useState<string>();
 
     const upload = async () => {
         setIsUploading(true);
@@ -50,6 +52,7 @@ export default function DocumentUpload({ session }: DocumentUploadProps): JSX.El
 
             if (fileUpload.ok) {
                 console.log("Uploaded successfully!");
+                setFileName(file.name);
                 setUploadSuccess(true);
             } else {
                 // TODO
@@ -146,7 +149,13 @@ export default function DocumentUpload({ session }: DocumentUploadProps): JSX.El
         return (
             <Wrapper session={session}>
                 <Box minHeight="85vh">
-                    <CloseButton href={redirect ? (redirect as string) : undefined} />
+                    <CloseButton
+                        href={
+                            redirect
+                                ? pathWithQuery(redirect as string, "uploaded", fileName)
+                                : undefined
+                        }
+                    />
                     <VStack>
                         <Center>
                             <Box width="400px" mb="40px">
@@ -187,7 +196,15 @@ export default function DocumentUpload({ session }: DocumentUploadProps): JSX.El
                                             mt="20px"
                                             onClick={() =>
                                                 router
-                                                    .push(redirect ? (redirect as string) : "/")
+                                                    .push(
+                                                        redirect
+                                                            ? pathWithQuery(
+                                                                  redirect as string,
+                                                                  "uploaded",
+                                                                  fileName,
+                                                              )
+                                                            : "/",
+                                                    )
                                                     .then(() => {
                                                         window.scrollTo({ top: 0 });
                                                     })
@@ -247,6 +264,7 @@ export default function DocumentUpload({ session }: DocumentUploadProps): JSX.El
             </Wrapper>
         );
     };
+
     if (uploadSuccess) {
         return uploadSuccessUI();
     } else {

--- a/pages/parent/signup.tsx
+++ b/pages/parent/signup.tsx
@@ -89,7 +89,7 @@ const FormPage = (props) => {
  */
 export default function ParticipantInfo({ session }: { session: Session }): JSX.Element {
     const router = useRouter();
-    const { page } = router.query;
+    const { page, uploaded } = router.query;
     const { t } = useTranslation("form");
     const [progressBar, setProgressBar] = useState(Number);
     const [pageNum, setPageNum] = useState<number>(page ? parseInt(page as string, 10) : 0);
@@ -417,9 +417,10 @@ export default function ParticipantInfo({ session }: { session: Session }): JSX.
 
         const parentData: ParentInput = {
             phoneNumber: parentPhoneNumber,
-            isLowIncome: undefined, // TODO
+            isLowIncome: undefined,
             preferredLanguage: locale.en,
-            proofOfIncomeLink: undefined, // TODO
+            proofOfIncomeLink: uploaded ? (uploaded as string) : undefined,
+            proofOfIncomeSubmittedAt: uploaded ? new Date() : undefined,
             heardFrom: [],
             createStudentInput: {
                 firstName: participantFirstName,

--- a/pages/volunteer/enrollment.tsx
+++ b/pages/volunteer/enrollment.tsx
@@ -8,6 +8,7 @@ import { UpdateCriminalCheckForm } from "@components/volunteer-enroll/UpdateCrim
 import { VolunteerEnrolledFormWrapper } from "@components/volunteer-enroll/VolunteerEnrollFormWrapper";
 import { locale } from "@prisma/client";
 import CardInfoUtil from "@utils/cardInfoUtil";
+import checkExpiry from "@utils/checkExpiry";
 import { fetcherWithQuery } from "@utils/fetcher";
 import useMe from "@utils/hooks/useMe";
 import useVolunteerRegistrations from "@utils/hooks/useVolunteerRegistration";
@@ -111,7 +112,7 @@ export const VolunteerEnrollment: React.FC<VolunteerEnrollmentProps> = ({
     // render update criminal check form if expired
     !me.volunteer.criminalRecordCheckLink
         ? pageElements.unshift(<SubmitCriminalCheckForm classInfo={classInfo} onNext={nextPage} />)
-        : me.volunteer.criminalCheckExpired
+        : checkExpiry(me.volunteer.criminalCheckSubmittedAt)
         ? pageElements.unshift(<UpdateCriminalCheckForm classInfo={classInfo} onNext={nextPage} />)
         : {};
 

--- a/pages/volunteer/signup.tsx
+++ b/pages/volunteer/signup.tsx
@@ -82,7 +82,7 @@ const FormPage = (props) => {
  */
 export default function VolunteerInfo({ session }: { session: Session }): JSX.Element {
     const router = useRouter();
-    const { page } = router.query;
+    const { page, uploaded } = router.query;
     const { t } = useTranslation("form");
     const [progressBar, setProgressBar] = useState(Number);
     const [pageNum, setPageNum] = useState<number>(page ? parseInt(page as string, 10) : 0);
@@ -217,7 +217,8 @@ export default function VolunteerInfo({ session }: { session: Session }): JSX.El
         const volunteerData: VolunteerInput = {
             dateOfBirth: new Date(dateOfBirth),
             phoneNumber: phoneNumber,
-            criminalRecordCheckLink: undefined,
+            criminalRecordCheckLink: uploaded ? (uploaded as string) : undefined,
+            criminalCheckSubmittedAt: uploaded ? new Date() : undefined,
             addressLine1: address1,
             postalCode: postalCode,
             cityName: city,

--- a/services/database/user.ts
+++ b/services/database/user.ts
@@ -209,6 +209,7 @@ async function updateUser(userInput: UserInput) {
                               isLowIncome: parentData.isLowIncome,
                               preferredLanguage: parentData.preferredLanguage,
                               proofOfIncomeLink: parentData.proofOfIncomeLink,
+                              proofOfIncomeSubmittedAt: parentData.proofOfIncomeSubmittedAt,
                               heardFrom: parentData.heardFrom,
                               user: {
                                   connect: { id: user.id },
@@ -249,6 +250,7 @@ async function updateUser(userInput: UserInput) {
                               phoneNumber: parentData.phoneNumber,
                               isLowIncome: parentData.isLowIncome,
                               proofOfIncomeLink: parentData.proofOfIncomeLink,
+                              proofOfIncomeSubmittedAt: parentData.proofOfIncomeSubmittedAt,
                               preferredLanguage: parentData.preferredLanguage,
                               heardFrom: parentData.heardFrom,
                               students: {
@@ -340,6 +342,7 @@ async function updateUser(userInput: UserInput) {
                         phoneNumber: volunteerData.phoneNumber,
                         dateOfBirth: volunteerData.dateOfBirth,
                         criminalRecordCheckLink: volunteerData.criminalRecordCheckLink,
+                        criminalCheckSubmittedAt: volunteerData.criminalCheckSubmittedAt,
                         addressLine1: volunteerData.addressLine1,
                         postalCode: volunteerData.postalCode,
                         cityName: volunteerData.cityName,
@@ -356,6 +359,7 @@ async function updateUser(userInput: UserInput) {
                         phoneNumber: volunteerData.phoneNumber,
                         dateOfBirth: volunteerData.dateOfBirth,
                         criminalRecordCheckLink: volunteerData.criminalRecordCheckLink,
+                        criminalCheckSubmittedAt: volunteerData.criminalCheckSubmittedAt,
                         addressLine1: volunteerData.addressLine1,
                         postalCode: volunteerData.postalCode,
                         cityName: volunteerData.cityName,

--- a/utils/validation/user.ts
+++ b/utils/validation/user.ts
@@ -116,6 +116,11 @@ function getUserValidationErrors(user: UserInput): Array<string> {
         if (!validatePreferredLanguage(roleData.preferredLanguage)) {
             validationErrors.push(`Invalid preferred language: ${roleData.preferredLanguage}`);
         }
+        if (roleData.proofOfIncomeLink && !roleData.proofOfIncomeSubmittedAt) {
+            validationErrors.push(
+                `Invalid submit date provided: ${roleData.proofOfIncomeSubmittedAt}`,
+            );
+        }
     } else if (user.role === roles.PROGRAM_ADMIN) {
         // pass - since program admin has no unique fields
     } else if (user.role === roles.TEACHER) {
@@ -134,6 +139,11 @@ function getUserValidationErrors(user: UserInput): Array<string> {
         if (roleData.preferredLanguage && !validatePreferredLanguage(roleData.preferredLanguage)) {
             validationErrors.push(
                 `Invalid preferred language provided: ${roleData.preferredLanguage}`,
+            );
+        }
+        if (roleData.criminalRecordCheckLink && !roleData.criminalCheckSubmittedAt) {
+            validationErrors.push(
+                `Invalid submit date provided: ${roleData.criminalCheckSubmittedAt}`,
             );
         }
     }


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[BUG: When trying to upload criminal check or proof of income before parent/volunteer user is created, the file will not be saved](https://www.notion.so/uwblueprintexecs/BUG-When-trying-to-upload-criminal-check-or-proof-of-income-before-parent-volunteer-user-is-created-f0929e92c23c45518a3786749c3dca60)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Add `uploaded` query param in upload doc page  when redirecting. This value is used in the signup form to be passed into the POST /api/user call

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Submission and viewing docs works for both parent and volunteers
2. Updating user irrelevant profiles fields does not reset link or submit dates

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
