### PR TITLE
feat(myaccounts): add link to open uploaded doc

### DIFF
--- a/pages/myaccounts.tsx
+++ b/pages/myaccounts.tsx
@@ -159,7 +159,7 @@ export default function MyAccount({ session }: MyAccountProps): JSX.Element {
                 component: (
                     <ProofOfIncome
                         approved={me.parent.isLowIncome}
-                        link={me.parent.proofOfIncomeLink}
+                        file={me.parent.proofOfIncomeLink}
                         submitDate={me.parent.proofOfIncomeSubmittedAt}
                     />
                 ),
@@ -193,7 +193,7 @@ export default function MyAccount({ session }: MyAccountProps): JSX.Element {
                 component: (
                     <CriminalCheck
                         approved={me.volunteer.criminalCheckApproved}
-                        link={me.volunteer.criminalRecordCheckLink}
+                        file={me.volunteer.criminalRecordCheckLink}
                         submitDate={me.volunteer.criminalCheckSubmittedAt}
                     />
                 ),

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -57,6 +57,7 @@
         "status_expired": "Status: Expired",
         "status_declined": "Status: Declined",
         "dateSubmitted": "Date submitted: {{date}}",
+        "document": "Document",
         "poi_approved": "Your income statement has been approved. Please be on the lookout for an email from SDC with the discount for future registrations.",
         "poi_pending": "Your income statement is under review.",
         "poi_declined": "You have been declined for low income discounts. Please contact SDC if you think this is a mistake or submit a new income statement.",

--- a/src/components/myAccounts/CriminalCheck.tsx
+++ b/src/components/myAccounts/CriminalCheck.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Text, Link as ChakraLink } from "@chakra-ui/react";
 import colourTheme from "@styles/colours";
 import Link from "next/link";
 import { ApprovedIcon, InfoIcon, PendingIcon } from "@components/icons";
@@ -7,19 +7,22 @@ import convertToShortDateString from "@utils/convertToShortDateString";
 import { locale } from "@prisma/client";
 import { useTranslation } from "next-i18next";
 import checkExpiry from "@utils/checkExpiry";
+import useFileRetrieve from "@utils/hooks/useFileRetrieve";
+import { FileType } from "@utils/enum/filetype";
 
 type CriminalCheckProps = {
-    link: string;
+    file: string;
     approved: boolean;
     submitDate?: Date;
 };
 
 export const CriminalCheck: React.FC<CriminalCheckProps> = ({
-    link,
+    file,
     approved,
     submitDate,
 }): JSX.Element => {
     const { t } = useTranslation(["form", "common"]);
+    const { url: docLink } = useFileRetrieve(FileType.CRIMINAL_CHECK, file);
 
     let description;
     let status;
@@ -39,7 +42,7 @@ export const CriminalCheck: React.FC<CriminalCheckProps> = ({
             context: status,
         });
         icon = <ApprovedIcon />;
-    } else if (link == null) {
+    } else if (file == null) {
         description = t("bgc.missing");
         icon = <InfoIcon />;
     } else if (approved === null) {
@@ -69,7 +72,7 @@ export const CriminalCheck: React.FC<CriminalCheckProps> = ({
                 </Box>
             </Flex>
             <Box pl={120} my={5} color={colourTheme.colors.Gray}>
-                {link == null ? null : (
+                {file == null ? null : (
                     <>
                         <Text>
                             {t("account.status", {
@@ -83,6 +86,17 @@ export const CriminalCheck: React.FC<CriminalCheckProps> = ({
                                 date: convertToShortDateString(submitDate, locale.en, true),
                             })}
                         </Text>
+                        <Flex>
+                            <Text pr={1}>
+                                {t("account.document", {
+                                    ns: "common",
+                                })}
+                                :{" "}
+                            </Text>
+                            <ChakraLink href={docLink} isExternal>
+                                {file}
+                            </ChakraLink>
+                        </Flex>
                     </>
                 )}
             </Box>

--- a/src/components/myAccounts/ProofOfIncome.tsx
+++ b/src/components/myAccounts/ProofOfIncome.tsx
@@ -1,24 +1,27 @@
 import React from "react";
-import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Text, Link as ChakraLink } from "@chakra-ui/react";
 import colourTheme from "@styles/colours";
 import Link from "next/link";
 import { ApprovedIcon, InfoIcon, PendingIcon } from "@components/icons";
 import convertToShortDateString from "@utils/convertToShortDateString";
 import { locale } from "@prisma/client";
 import { useTranslation } from "react-i18next";
+import useFileRetrieve from "@utils/hooks/useFileRetrieve";
+import { FileType } from "@utils/enum/filetype";
 
 type ProofOfIncomeProps = {
-    link: string;
+    file: string;
     approved: boolean;
     submitDate?: Date;
 };
 
 export const ProofOfIncome: React.FC<ProofOfIncomeProps> = ({
-    link,
+    file,
     approved,
     submitDate,
 }): JSX.Element => {
     const { t } = useTranslation(["form", "common"]);
+    const { url: docLink } = useFileRetrieve(FileType.INCOME_PROOF, file);
 
     let description;
     let status;
@@ -31,7 +34,7 @@ export const ProofOfIncome: React.FC<ProofOfIncomeProps> = ({
             context: status,
         });
         icon = <ApprovedIcon />;
-    } else if (link == null) {
+    } else if (file == null) {
         description = t("poi.missing");
         icon = <InfoIcon />;
     } else if (approved === null) {
@@ -61,7 +64,7 @@ export const ProofOfIncome: React.FC<ProofOfIncomeProps> = ({
                 </Box>
             </Flex>
             <Box pl={120} my={5} color={colourTheme.colors.Gray}>
-                {link == null ? null : (
+                {file == null ? null : (
                     <>
                         <Text>
                             {t("account.status", {
@@ -75,6 +78,17 @@ export const ProofOfIncome: React.FC<ProofOfIncomeProps> = ({
                                 date: convertToShortDateString(submitDate, locale.en, true),
                             })}
                         </Text>
+                        <Flex>
+                            <Text pr={1}>
+                                {t("account.document", {
+                                    ns: "common",
+                                })}
+                                :{" "}
+                            </Text>
+                            <ChakraLink href={docLink} isExternal>
+                                {file}
+                            </ChakraLink>
+                        </Flex>
                     </>
                 )}
             </Box>


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add Doc Link to My Account](https://www.notion.so/uwblueprintexecs/Add-Doc-Link-to-My-Account-60748dd9ad4e4c3382b6f80d7da37e87)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

https://user-images.githubusercontent.com/44826218/147609210-09295f67-03c3-4e10-9acb-f689268ed778.mp4

Same for parent account page:
![image](https://user-images.githubusercontent.com/44826218/147609447-2eac8ce5-98d7-4f8a-a659-c1abbe23c728.png)

- Use the file retrieval hook to integrate view uploaded doc feature in my accounts page

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Parent and volunteers should be able to view their own docs

### Checklist

-   [X] My PR name is descriptive and in imperative tense
-   [X] I have run the linter
-   [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
