### PR TITLE
feat(badges): onlineFormat proper spacing + cap

### DIFF
--- a/pages/admin/archive/index.tsx
+++ b/pages/admin/archive/index.tsx
@@ -32,6 +32,7 @@ import { AdminLoading } from "@components/AdminLoading";
 import { weekdayToString } from "@utils/enum/weekday";
 import { ArchivedProgramClassInfoCard } from "@components/admin/ArchivedProgramClassInfoCard";
 import { mutate } from "swr";
+import convertCamelToText from "@utils/convertCamelToText";
 
 type ArchiveBrowseProgramsProps = {
     session: Session;
@@ -68,6 +69,7 @@ export const ArchiveBrowsePrograms: React.FC<ArchiveBrowseProgramsProps> = (prop
         } else if (
             prog.name.toLowerCase().includes(term) ||
             prog.description.toLowerCase().includes(term) ||
+            convertCamelToText(prog.onlineFormat).toLowerCase().includes(term) ||
             prog.onlineFormat.toLowerCase().includes(term) ||
             prog.tag.toLowerCase().includes(term)
         ) {

--- a/pages/admin/program/index.tsx
+++ b/pages/admin/program/index.tsx
@@ -17,6 +17,7 @@ import { AdminLoading } from "@components/AdminLoading";
 import { AdminError } from "@components/AdminError";
 import { isInternal } from "@utils/session/authorization";
 import { roles } from "@prisma/client";
+import convertCamelToText from "@utils/convertCamelToText";
 
 type BrowseProgramsProps = {
     session: Session;
@@ -46,6 +47,7 @@ export const BrowsePrograms: React.FC<BrowseProgramsProps> = (props) => {
         } else if (
             prog.name.toLowerCase().includes(term) ||
             prog.description.toLowerCase().includes(term) ||
+            convertCamelToText(prog.onlineFormat).toLowerCase().includes(term) ||
             prog.onlineFormat.toLowerCase().includes(term) ||
             prog.tag.toLowerCase().includes(term)
         ) {

--- a/src/components/ClassInfoModal.tsx
+++ b/src/components/ClassInfoModal.tsx
@@ -30,6 +30,7 @@ import { locale, roles } from "@prisma/client";
 import { UseMeResponse } from "@utils/hooks/useMe";
 import { infoToastOptions } from "@utils/toast/options";
 import { totalMinutes } from "@utils/time/convert";
+import convertCamelToText from "@utils/convertCamelToText";
 
 type ClassInfoModalProps = {
     isOpen: boolean;
@@ -83,7 +84,7 @@ export const ClassInfoModal: React.FC<ClassInfoModalProps> = ({
                         })}
                     </Text>
                     <Box my={25}>
-                        <SDCBadge children={onlineFormat} />
+                        <SDCBadge children={convertCamelToText(onlineFormat)} />
                         <SDCBadge children={tag} ml={2} />
                     </Box>
                     <Text>{classInfo.description}</Text>

--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { Session } from "next-auth";
+import convertCamelToText from "@utils/convertCamelToText";
 
 type ProgramCardProps = {
     styleProps?: Record<string, unknown>;
@@ -110,7 +111,10 @@ export const ProgramCard: React.FC<ProgramCardProps> = ({ cardInfo }): JSX.Eleme
                                         </Box>
                                         <Box mt="2">
                                             <SDCBadge children={item.tag} />
-                                            <SDCBadge ml="2" children={item.onlineFormat} />
+                                            <SDCBadge
+                                                ml="2"
+                                                children={convertCamelToText(item.onlineFormat)}
+                                            />
                                         </Box>
                                     </Box>
                                 </Box>

--- a/src/components/ProgramInfo.tsx
+++ b/src/components/ProgramInfo.tsx
@@ -27,6 +27,7 @@ import { EmptyState } from "./EmptyState";
 import Participants from "@utils/containers/Participants";
 import { UseMeResponse } from "@utils/hooks/useMe";
 import { Session } from "next-auth";
+import convertCamelToText from "@utils/convertCamelToText";
 
 /**
  * programInfo is the program information that will be displayed on the home page, follows the ProgramCardInfo type
@@ -67,7 +68,7 @@ export const ProgramInfo: React.FC<ProgramDetailsProps> = ({
 
     const programTags = (
         <Box>
-            <SDCBadge children={programInfo.onlineFormat} />
+            <SDCBadge children={convertCamelToText(programInfo.onlineFormat)} />
             <SDCBadge ml="2" children={programInfo.tag} />
         </Box>
     );

--- a/src/components/admin/ArchivedBrowseProgramCard.tsx
+++ b/src/components/admin/ArchivedBrowseProgramCard.tsx
@@ -16,6 +16,7 @@ import {
 import { AdminBadge } from "@components/AdminBadge";
 import { locale, roles } from "@prisma/client";
 import colourTheme from "@styles/colours";
+import convertCamelToText from "@utils/convertCamelToText";
 import convertToShortDateRange from "@utils/convertToShortDateRange";
 import { deleteProgram } from "@utils/deleteProgram";
 import { infoToastOptions } from "@utils/toast/options";
@@ -134,7 +135,7 @@ export const ArchivedBrowseProgramCard: React.FC<ArchivedBrowseProgramCardProps>
                     </Tooltip>
                     <Box mt={6}>
                         <AdminBadge>{cardInfo.tag}</AdminBadge>
-                        <AdminBadge ml={2}>{cardInfo.onlineFormat}</AdminBadge>
+                        <AdminBadge ml={2}>{convertCamelToText(cardInfo.onlineFormat)}</AdminBadge>
                     </Box>
                 </Box>
             </Box>

--- a/src/components/admin/ArchivedProgramViewInfoCard.tsx
+++ b/src/components/admin/ArchivedProgramViewInfoCard.tsx
@@ -32,6 +32,7 @@ import { IoEllipsisVertical } from "react-icons/io5";
 import { AdminModal } from "./AdminModal";
 import { roles } from "@prisma/client";
 import { infoToastOptions } from "@utils/toast/options";
+import convertCamelToText from "@utils/convertCamelToText";
 
 export type ArchivedProgramViewInfoCard = {
     cardInfo: ProgramCardInfo;
@@ -138,7 +139,9 @@ export const ArchivedProgramViewInfoCard: React.FC<ArchivedProgramViewInfoCard> 
                         </Flex>
                         <Flex>
                             <AdminBadge>{cardInfo.tag}</AdminBadge>
-                            <AdminBadge ml={2}>{cardInfo.onlineFormat}</AdminBadge>
+                            <AdminBadge ml={2}>
+                                {convertCamelToText(cardInfo.onlineFormat)}
+                            </AdminBadge>
                         </Flex>
                     </VStack>
                 </GridItem>

--- a/src/components/admin/BrowseProgramCard.tsx
+++ b/src/components/admin/BrowseProgramCard.tsx
@@ -16,6 +16,7 @@ import {
 import { AdminBadge } from "@components/AdminBadge";
 import { locale, roles } from "@prisma/client";
 import colourTheme from "@styles/colours";
+import convertCamelToText from "@utils/convertCamelToText";
 import convertToShortDateRange from "@utils/convertToShortDateRange";
 import { deleteProgram } from "@utils/deleteProgram";
 import { infoToastOptions } from "@utils/toast/options";
@@ -129,7 +130,7 @@ export const BrowseProgramCard: React.FC<BrowseProgramCardProps> = ({
                     </Tooltip>
                     <Box mt={6}>
                         <AdminBadge>{cardInfo.tag}</AdminBadge>
-                        <AdminBadge ml={2}>{cardInfo.onlineFormat}</AdminBadge>
+                        <AdminBadge ml={2}>{convertCamelToText(cardInfo.onlineFormat)}</AdminBadge>
                     </Box>
                 </Box>
             </Box>

--- a/src/components/admin/ProgramViewInfoCard.tsx
+++ b/src/components/admin/ProgramViewInfoCard.tsx
@@ -32,6 +32,7 @@ import { IoEllipsisVertical } from "react-icons/io5";
 import { AdminModal } from "./AdminModal";
 import { roles } from "@prisma/client";
 import { infoToastOptions } from "@utils/toast/options";
+import convertCamelToText from "@utils/convertCamelToText";
 
 export type ProgramViewInfoCard = {
     cardInfo: ProgramCardInfo;
@@ -132,7 +133,9 @@ export const ProgramViewInfoCard: React.FC<ProgramViewInfoCard> = ({ cardInfo, r
                         </Flex>
                         <Flex>
                             <AdminBadge>{cardInfo.tag}</AdminBadge>
-                            <AdminBadge ml={2}>{cardInfo.onlineFormat}</AdminBadge>
+                            <AdminBadge ml={2}>
+                                {convertCamelToText(cardInfo.onlineFormat)}
+                            </AdminBadge>
                         </Flex>
                     </VStack>
                 </GridItem>

--- a/utils/convertCamelToText.ts
+++ b/utils/convertCamelToText.ts
@@ -1,0 +1,10 @@
+/**
+ * Converts camel case string into normal text
+ * EG: "inPerson" -> "In Person"
+ * @param text Camel case text
+ * @returns the corresponding normal text with proper spacing
+ */
+export default function convertCamelToText(text: string): string {
+    const result = text.replace(/([A-Z])/g, " $1");
+    return result.charAt(0).toUpperCase() + result.slice(1);
+}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- add new util function that converts camelCase strings into properly spaced/capitalized string output

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. All places with program format badges now shows the text with proper capitalization and spacing (eg: "inPerson" -> "In Person")