### PR TITLE
fix(parent/signup): remove extra label

### DIFF
--- a/src/components/parent-form/HeardFromPage.tsx
+++ b/src/components/parent-form/HeardFromPage.tsx
@@ -30,7 +30,6 @@ export const HeardFromPage: React.FC<HeardFromPageProps> = ({ props }): JSX.Elem
             <FormControl id="hear-about-us">
                 <FormLabel>{t("signUp.hearAboutUs")}</FormLabel>
                 <Stack direction="column">
-                    <FormLabel>{t("signUp.participantHaveDifficulties")}</FormLabel>
                     <CheckBoxField
                         value={props.heardFromFriendsAndFam}
                         name={t("hearAboutUs.friendsAndFamily", {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44826218/147891221-f40463f7-c610-4472-9065-4b26f8566dbc.png)

Before the change, we had an extra label that didn't belong.