### PR TITLE
fix: remove unexpected starttime-minutes from API call

### DIFF
--- a/pages/admin/class/edit/[id].tsx
+++ b/pages/admin/class/edit/[id].tsx
@@ -144,7 +144,6 @@ export default function CreateClass({ session }: Props): JSX.Element {
             endDate: new Date(endDate),
             price,
             id,
-            startTimeMinutes: moment(startDate).diff(moment().startOf("day"), "minutes"),
             durationMinutes: parseInt(durationMinutes),
             teacherRegs: [
                 {


### PR DESCRIPTION
Remove deprecated field from API call.